### PR TITLE
Prep v0.0.8 release

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -15,10 +15,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # Fetch tags manually per
+      # https://github.com/actions/checkout/issues/1471
+      - name: Fetch tags
+        run: git fetch --prune --unshallow --tags
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+
       - name: Build
         run: make -C v2 build dist
       - name: Test

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -19,13 +19,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
-      - name: Install dependencies
-        run: go get .
       - name: Build
-        run: make build
-      - name: Test with the Go CLI
-        run: make test
-      - name: Build v2
-        run: make -C v2 build
-      - name: Test v2
+        run: make -C v2 build dist
+      - name: Test
         run: make -C v2 test

--- a/archive/main.go
+++ b/archive/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"github.com/rescale/htc-storage-cli/cli"
+	"github.com/rescale-labs/htc-cli/cli"
 	"log"
 	"os"
 )

--- a/archive/main_test.go
+++ b/archive/main_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"errors"
-	"github.com/rescale/htc-storage-cli/cli"
+	"github.com/rescale-labs/htc-cli/cli"
 	"testing"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rescale/htc-storage-cli
+module github.com/rescale-labs/htc-cli
 
 go 1.23.1
 

--- a/v2/CHANGES.md
+++ b/v2/CHANGES.md
@@ -1,11 +1,16 @@
 # Changelog
 
-## Pending release
+## v0.0.8
 
 * Add `auth logout` for clearing existing stored API key and token.
 * Add `project create` with sample JSON in usage string.
 * Add `region get` to print the global list of HTC regions.
 * Extend `dimensions get` to support tabular text output by default.
+* Extend `job get` to support sorting by several fields.
+* Document that `job submit` can be fed from stdin and include a
+  sample JSON payload in usage string.
+* Fix top level help text so that all subcommands have applicable
+  headings.
 
 ## v0.0.7
 

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -21,7 +21,7 @@ ifeq ($(UNAME_S),Darwin)
 	HOST_OS := darwin
 endif
 
-GO_PACKAGE := github.com/rescale/htc-storage-cli/v2
+GO_PACKAGE := github.com/rescale-labs/htc-cli/v2
 
 # Create statically linked binaries.
 GO_BUILD := CGO_ENABLED=0 go build
@@ -134,30 +134,6 @@ test:
 	$(GO_OPTS) go test ./...
 
 godoc:
-	@echo "view oapi docs on: http://localhost:6060/pkg/github.com/rescale/htc-storage-cli/v2/api/_oas/"
+	@echo "view oapi docs on: http://localhost:6060/pkg/github.com/rescale-labs/htc-cli/v2/api/_oas/"
 	@echo
 	godoc -http=localhost:6060
-
-#
-# Uploading to S3
-#
-# Will be removed if we switch the repo over to rescale labs and open
-# source it.
-
-S3_CP := aws --profile dev s3 cp
-S3_BUCKET := rescale-htc-cli-agae5ucedee8kohtaet8naekx
-S3_DIR := rescale-htc-storage/htc-cli
-S3_PREFIX := s3://$(S3_BUCKET)/$(S3_DIR)
-S3_HTTPS_URL := https://$(S3_BUCKET).s3.eu-west-1.amazonaws.com/$(S3_DIR)
-
-.PHONY: login-s3
-login-s3:
-	aws sso login --profile dev
-
-.PHONY: upload
-upload:
-	$(foreach archive,$(DIST_ARCHIVES),$(S3_CP) $(archive) $(S3_PREFIX)/$(notdir $(archive));)
-	@echo
-	@echo "Archives available at"
-	@echo
-	@$(foreach archive,$(DIST_ARCHIVES),echo "  " $(S3_HTTPS_URL)/$(notdir $(archive));)

--- a/v2/TODO.md
+++ b/v2/TODO.md
@@ -60,7 +60,6 @@ Automation:
     * Brian would like to be able to add extra columns to tabular output.
     * Brian would like `htc config edit` that drops into an editor.
 
-
 ## stuff from Alistair 2024-10-22
 
 things we run a lot in my team are:
@@ -164,5 +163,9 @@ I can give example output from any of the above / existing scripting, if that he
 * Eventually support project deletion along the lines of
   https://rescale.atlassian.net/browse/ENK-2095 ?
 * Show the last job run in a task/project/workspace.
+
+Security:
+  * Before we can deprecate htcctl, we'll need to do security certification for `htc`. (See Rescale internal sync notes from 2024-11-26.)
+
 
 <!-- vim: set tw=999999 sts=0 ts=2 sw=2: -->

--- a/v2/cmd/htc/main.go
+++ b/v2/cmd/htc/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/rescale/htc-storage-cli/v2/commands"
+	"github.com/rescale-labs/htc-cli/v2/commands"
 )
 
 func main() {

--- a/v2/commands/auth/command.go
+++ b/v2/commands/auth/command.go
@@ -5,7 +5,8 @@ import (
 )
 
 var AuthCmd = &cobra.Command{
-	Use: "auth",
+	Use:   "auth",
+	Short: "Log in and out of HTC",
 }
 
 func init() {

--- a/v2/commands/auth/login.go
+++ b/v2/commands/auth/login.go
@@ -1,7 +1,7 @@
 package auth
 
 import (
-	"github.com/rescale/htc-storage-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/common"
 	"github.com/spf13/cobra"
 )
 

--- a/v2/commands/auth/logout.go
+++ b/v2/commands/auth/logout.go
@@ -1,7 +1,7 @@
 package auth
 
 import (
-	"github.com/rescale/htc-storage-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/common"
 	"github.com/spf13/cobra"
 )
 

--- a/v2/commands/auth/whoami.go
+++ b/v2/commands/auth/whoami.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 func WhoAmI(cmd *cobra.Command, args []string) error {

--- a/v2/commands/config/command.go
+++ b/v2/commands/config/command.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	cfgcontext "github.com/rescale/htc-storage-cli/v2/commands/config/context"
+	cfgcontext "github.com/rescale-labs/htc-cli/v2/commands/config/context"
 	"github.com/spf13/cobra"
 )
 

--- a/v2/commands/config/command.go
+++ b/v2/commands/config/command.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	cfgcontext "github.com/rescale/htc-storage-cli/v2/commands/config/context"
+	"github.com/spf13/cobra"
+)
+
+var ConfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage local configuration",
+}
+
+func init() {
+	ConfigCmd.AddCommand(SetCmd)
+	ConfigCmd.AddCommand(UnsetCmd)
+
+	contextCmd := &cobra.Command{
+		Use: "context",
+	}
+	contextCmd.AddCommand(cfgcontext.DeleteCmd)
+	contextCmd.AddCommand(cfgcontext.GetCmd)
+	contextCmd.AddCommand(cfgcontext.UseCmd)
+	ConfigCmd.AddCommand(contextCmd)
+}

--- a/v2/commands/config/context/delete.go
+++ b/v2/commands/config/context/delete.go
@@ -3,8 +3,8 @@ package context
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/rescale/htc-storage-cli/v2/common"
-	"github.com/rescale/htc-storage-cli/v2/config"
+	"github.com/rescale-labs/htc-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/config"
 )
 
 func deleteCmd(cmd *cobra.Command, args []string) error {

--- a/v2/commands/config/context/get.go
+++ b/v2/commands/config/context/get.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rescale/htc-storage-cli/v2/common"
-	"github.com/rescale/htc-storage-cli/v2/tabler"
+	"github.com/rescale-labs/htc-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/tabler"
 )
 
 func Get(cmd *cobra.Command, args []string) error {

--- a/v2/commands/config/context/use.go
+++ b/v2/commands/config/context/use.go
@@ -3,7 +3,7 @@ package context
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/rescale/htc-storage-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 func use(cmd *cobra.Command, args []string) error {

--- a/v2/commands/config/set.go
+++ b/v2/commands/config/set.go
@@ -3,8 +3,8 @@ package config
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/rescale/htc-storage-cli/v2/common"
-	"github.com/rescale/htc-storage-cli/v2/config"
+	"github.com/rescale-labs/htc-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/config"
 )
 
 func set(cmd *cobra.Command, args []string) error {

--- a/v2/commands/image/command.go
+++ b/v2/commands/image/command.go
@@ -5,7 +5,8 @@ import (
 )
 
 var ImageCmd = &cobra.Command{
-	Use: "image",
+	Use:   "image",
+	Short: "Commands for managing container images",
 }
 
 func init() {

--- a/v2/commands/image/common.go
+++ b/v2/commands/image/common.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
 )
 
 //

--- a/v2/commands/image/create_repo.go
+++ b/v2/commands/image/create_repo.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 func createRepo(ctx context.Context, c oapi.ImageInvoker, projectId, repoName string) (*oapi.HTCRepository, error) {

--- a/v2/commands/image/get.go
+++ b/v2/commands/image/get.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 func getImage(ctx context.Context, c oapi.ImageInvoker, projectId, imageName string) (*oapi.HTCImageStatus, error) {

--- a/v2/commands/image/login_repo.go
+++ b/v2/commands/image/login_repo.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rescale/htc-storage-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 func LoginRepo(cmd *cobra.Command, args []string) error {

--- a/v2/commands/image/push.go
+++ b/v2/commands/image/push.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rescale/htc-storage-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 func tagImage(ctx context.Context, image, targetName string) error {

--- a/v2/commands/job/command.go
+++ b/v2/commands/job/command.go
@@ -1,0 +1,15 @@
+package job
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var JobCmd = &cobra.Command{
+	Use:   "job",
+	Short: "Commands for HTC projects",
+}
+
+func init() {
+	JobCmd.AddCommand(SubmitCmd)
+	JobCmd.AddCommand(GetCmd)
+}

--- a/v2/commands/job/get.go
+++ b/v2/commands/job/get.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
-	"github.com/rescale/htc-storage-cli/v2/config"
-	"github.com/rescale/htc-storage-cli/v2/tabler"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/config"
+	"github.com/rescale-labs/htc-cli/v2/tabler"
 )
 
 const pageSize = 500

--- a/v2/commands/job/submit.go
+++ b/v2/commands/job/submit.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 type submitRequest struct {

--- a/v2/commands/job/submit.go
+++ b/v2/commands/job/submit.go
@@ -50,20 +50,14 @@ func Submit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Error setting group: %w", err)
 	}
 
-	var r *os.File
 	if len(args) != 1 {
 		return fmt.Errorf("Error: job yaml not provided")
 	}
-	if args[0] == "-" {
-		r = os.Stdin
-	} else {
-		var err error
-		r, err = os.Open(args[0])
-		if err != nil {
-			return fmt.Errorf("Error opening %s: %v", args[0], err)
-		}
-		defer r.Close()
+	f, err := common.OpenArg(args[0])
+	if err != nil {
+		return err
 	}
+	defer f.Close()
 
 	req := submitRequest{
 		params: oapi.SubmitJobsParams{
@@ -73,7 +67,7 @@ func Submit(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	dec := json.NewDecoder(r)
+	dec := json.NewDecoder(f)
 	if err := dec.Decode(&req.batch); err != nil {
 		return fmt.Errorf("Error parsing %s: %v", args[0], err)
 	}
@@ -87,15 +81,50 @@ func Submit(cmd *cobra.Command, args []string) error {
 }
 
 var SubmitCmd = &cobra.Command{
-	Use:   "submit JOB_BATCH_JSON",
+	Use:   "submit JSON_FILE",
 	Args:  cobra.ExactArgs(1),
 	Short: "Submits jobs for a given task and project",
-	// Long:
-	Run: common.WrapRunE(Submit),
+	Run:   common.WrapRunE(Submit),
 }
 
 func init() {
+	// Prepare a sample JSON payload for our example.
+	job := oapi.HTCJobSubmitRequest{
+		JobName: oapi.NewOptString("a-rescale-htc-job"),
+		HtcJobDefinition: oapi.HTCJobDefinition{
+			ImageName:  "rescale-rsj-load-test-image_alpine_x86:latest",
+			MaxVCpus:   oapi.NewOptInt32(1),
+			MaxMemory:  oapi.NewOptInt32(128),
+			MaxDiskGiB: oapi.NewOptInt32(1),
+			Commands:   []string{"/bin/sh", "-c", "sleep 5m; echo all done"},
+			Envs: []oapi.EnvPair{
+				oapi.EnvPair{"INPUT_BUCKET", "htc-rescale-bucket"},
+			},
+			ExecTimeoutSeconds: oapi.NewOptInt32(3600),
+			Priority:           oapi.NewOptJobPriority(oapi.JobPriorityONDEMANDPRIORITY),
+		},
+		BatchSize: oapi.NewOptInt32(1),
+		Regions: []oapi.RescaleRegion{
+			oapi.RescaleRegionGCPEUWEST2,
+		},
+		RetryStrategy: oapi.NewOptHTCRetryStrategy(
+			oapi.HTCRetryStrategy{MaxRetries: oapi.NewOptInt32(1)},
+		),
+	}
+
+	b, err := json.MarshalIndent(&job, "", "  ")
+	if err != nil {
+		panic("Unable to serialize `job create` JSON example: " + err.Error())
+	}
+
 	SubmitCmd.Flags().String("project-id", "", "HTC project ID (required)")
 	SubmitCmd.Flags().String("task-id", "", "HTC task ID (required)")
 	SubmitCmd.Flags().String("group", "", "Group")
+
+	SubmitCmd.Long = SubmitCmd.Short + `
+JSON_FILE is a path to a JSON file or - for stdin.`
+	SubmitCmd.Example = fmt.Sprintf(`
+htc job submit - <<'EOF'
+  %s
+EOF`, string(b))
 }

--- a/v2/commands/metrics/command.go
+++ b/v2/commands/metrics/command.go
@@ -1,0 +1,14 @@
+package metrics
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var MetricsCmd = &cobra.Command{
+	Use:   "metrics",
+	Short: "Fetch HTC metrics in OpenMetrics format",
+}
+
+func init() {
+	MetricsCmd.AddCommand(GetCmd)
+}

--- a/v2/commands/metrics/get.go
+++ b/v2/commands/metrics/get.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 func getMetrics(ctx context.Context, c oapi.MetricsInvoker) (io.Reader, error) {

--- a/v2/commands/project/command.go
+++ b/v2/commands/project/command.go
@@ -5,7 +5,8 @@ import (
 )
 
 var ProjectCmd = &cobra.Command{
-	Use: "project",
+	Use:   "project",
+	Short: "Commands for HTC projects",
 }
 
 func init() {

--- a/v2/commands/project/create.go
+++ b/v2/commands/project/create.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 func createProject(cmd *cobra.Command, args []string) error {

--- a/v2/commands/project/dimensions.go
+++ b/v2/commands/project/dimensions.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
-	"github.com/rescale/htc-storage-cli/v2/tabler"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/tabler"
 )
 
 func DimensionsGet(cmd *cobra.Command, args []string) error {

--- a/v2/commands/project/get.go
+++ b/v2/commands/project/get.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
-	"github.com/rescale/htc-storage-cli/v2/tabler"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/tabler"
 )
 
 const pageSize = 500

--- a/v2/commands/project/get.go
+++ b/v2/commands/project/get.go
@@ -73,8 +73,8 @@ func Get(cmd *cobra.Command, args []string) error {
 }
 
 var GetCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Returns HTC projects in a workspace",
+	Use:   "get [PROJECT_ID]",
+	Short: "Returns all HTC projects, or a single project, in the current workspace",
 	// Long:
 	Run: common.WrapRunE(Get),
 }

--- a/v2/commands/project/limits.go
+++ b/v2/commands/project/limits.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 func LimitsGet(cmd *cobra.Command, args []string) error {

--- a/v2/commands/project/retention_policy.go
+++ b/v2/commands/project/retention_policy.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 func getRetentionPolicy(cmd *cobra.Command, args []string) error {

--- a/v2/commands/region/command.go
+++ b/v2/commands/region/command.go
@@ -24,7 +24,8 @@ func getRegions(cmd *cobra.Command, _ []string) error {
 }
 
 var RegionCmd = &cobra.Command{
-	Use: "region",
+	Use:   "region",
+	Short: "List HTC regions",
 }
 
 var GetCmd = &cobra.Command{

--- a/v2/commands/region/command.go
+++ b/v2/commands/region/command.go
@@ -3,9 +3,9 @@ package region
 import (
 	"os"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
-	"github.com/rescale/htc-storage-cli/v2/tabler"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/tabler"
 	"github.com/spf13/cobra"
 )
 

--- a/v2/commands/root.go
+++ b/v2/commands/root.go
@@ -3,15 +3,15 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/rescale/htc-storage-cli/v2/commands/auth"
-	"github.com/rescale/htc-storage-cli/v2/commands/config"
-	"github.com/rescale/htc-storage-cli/v2/commands/image"
-	"github.com/rescale/htc-storage-cli/v2/commands/job"
-	"github.com/rescale/htc-storage-cli/v2/commands/metrics"
-	"github.com/rescale/htc-storage-cli/v2/commands/project"
-	"github.com/rescale/htc-storage-cli/v2/commands/region"
-	"github.com/rescale/htc-storage-cli/v2/commands/task"
-	"github.com/rescale/htc-storage-cli/v2/commands/version"
+	"github.com/rescale-labs/htc-cli/v2/commands/auth"
+	"github.com/rescale-labs/htc-cli/v2/commands/config"
+	"github.com/rescale-labs/htc-cli/v2/commands/image"
+	"github.com/rescale-labs/htc-cli/v2/commands/job"
+	"github.com/rescale-labs/htc-cli/v2/commands/metrics"
+	"github.com/rescale-labs/htc-cli/v2/commands/project"
+	"github.com/rescale-labs/htc-cli/v2/commands/region"
+	"github.com/rescale-labs/htc-cli/v2/commands/task"
+	"github.com/rescale-labs/htc-cli/v2/commands/version"
 )
 
 var RootCmd = &cobra.Command{

--- a/v2/commands/root.go
+++ b/v2/commands/root.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/rescale/htc-storage-cli/v2/commands/auth"
 	"github.com/rescale/htc-storage-cli/v2/commands/config"
-	cfgcontext "github.com/rescale/htc-storage-cli/v2/commands/config/context"
 	"github.com/rescale/htc-storage-cli/v2/commands/image"
 	"github.com/rescale/htc-storage-cli/v2/commands/job"
 	"github.com/rescale/htc-storage-cli/v2/commands/metrics"
@@ -19,7 +18,7 @@ var RootCmd = &cobra.Command{
 	Use:   "htc",
 	Short: "The CLI for Rescale's High Throughput Computing (HTC) API",
 	Long: `htc provides easy access to key parts of Rescale's HTC API.
-  	See https://htc.rescale.com/docs/ for more details.`,
+See https://htc.rescale.com/docs/ for more details.`,
 }
 
 func init() {
@@ -31,39 +30,16 @@ func init() {
 	RootCmd.AddCommand(auth.AuthCmd)
 
 	// config
-	configCmd := &cobra.Command{
-		Use: "config",
-	}
-	configCmd.AddCommand(config.SetCmd)
-	configCmd.AddCommand(config.UnsetCmd)
-	RootCmd.AddCommand(configCmd)
-
-	// config context
-	contextCmd := &cobra.Command{
-		Use: "context",
-	}
-	contextCmd.AddCommand(cfgcontext.DeleteCmd)
-	contextCmd.AddCommand(cfgcontext.GetCmd)
-	contextCmd.AddCommand(cfgcontext.UseCmd)
-	configCmd.AddCommand(contextCmd)
+	RootCmd.AddCommand(config.ConfigCmd)
 
 	// image
 	RootCmd.AddCommand(image.ImageCmd)
 
 	// job
-	jobCmd := &cobra.Command{
-		Use: "job",
-	}
-	jobCmd.AddCommand(job.SubmitCmd)
-	jobCmd.AddCommand(job.GetCmd)
-	RootCmd.AddCommand(jobCmd)
+	RootCmd.AddCommand(job.JobCmd)
 
 	// metrics
-	metricsCmd := &cobra.Command{
-		Use: "metrics",
-	}
-	metricsCmd.AddCommand(metrics.GetCmd)
-	RootCmd.AddCommand(metricsCmd)
+	RootCmd.AddCommand(metrics.MetricsCmd)
 
 	// project
 	RootCmd.AddCommand(project.ProjectCmd)
@@ -72,12 +48,7 @@ func init() {
 	RootCmd.AddCommand(region.RegionCmd)
 
 	// task
-	taskCmd := &cobra.Command{
-		Use: "task",
-	}
-	taskCmd.AddCommand(task.CreateCmd)
-	taskCmd.AddCommand(task.GetCmd)
-	RootCmd.AddCommand(taskCmd)
+	RootCmd.AddCommand(task.TaskCmd)
 
 	// version
 	RootCmd.AddCommand(version.Cmd)

--- a/v2/commands/task/command.go
+++ b/v2/commands/task/command.go
@@ -1,0 +1,15 @@
+package task
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var TaskCmd = &cobra.Command{
+	Use:   "task",
+	Short: "Commands for managing HTC tasks",
+}
+
+func init() {
+	TaskCmd.AddCommand(CreateCmd)
+	TaskCmd.AddCommand(GetCmd)
+}

--- a/v2/commands/task/create.go
+++ b/v2/commands/task/create.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
 )
 
 func createTask(ctx context.Context, c oapi.TaskInvoker, projectId, name, desc string) (*oapi.HTCTask, error) {

--- a/v2/commands/task/get.go
+++ b/v2/commands/task/get.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/common"
-	"github.com/rescale/htc-storage-cli/v2/config"
-	"github.com/rescale/htc-storage-cli/v2/tabler"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/config"
+	"github.com/rescale-labs/htc-cli/v2/tabler"
 )
 
 const pageSize = 500

--- a/v2/commands/version/version.go
+++ b/v2/commands/version/version.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/rescale/htc-storage-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/common"
 	"github.com/spf13/cobra"
 )
 

--- a/v2/commands/version/version.go
+++ b/v2/commands/version/version.go
@@ -20,7 +20,7 @@ var Version = "devel"
 
 var Cmd = &cobra.Command{
 	Use:   "version",
-	Short: "Returns HTC tasks in a given project.",
+	Short: "Prints version of this CLI tool",
 	Run: common.WrapRunE(
 		func(cmd *cobra.Command, _ []string) error {
 			_, err := fmt.Printf(

--- a/v2/common/common.go
+++ b/v2/common/common.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rescale/htc-storage-cli/v2/config"
+	"github.com/rescale-labs/htc-cli/v2/config"
 )
 
 func WrapRunE(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) {

--- a/v2/common/runner.go
+++ b/v2/common/runner.go
@@ -14,9 +14,9 @@ import (
 	"github.com/go-faster/yaml"
 	"github.com/spf13/cobra"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
-	"github.com/rescale/htc-storage-cli/v2/config"
-	"github.com/rescale/htc-storage-cli/v2/tabler"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/config"
+	"github.com/rescale-labs/htc-cli/v2/tabler"
 )
 
 // Wrap http.Client so that we can set auth headers appropriately

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
 	"github.com/spf13/cobra"
 )
 

--- a/v2/tabler/config_context.go
+++ b/v2/tabler/config_context.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"unicode/utf8"
 
-	"github.com/rescale/htc-storage-cli/v2/config"
+	"github.com/rescale-labs/htc-cli/v2/config"
 )
 
 type ContextIdentity struct {

--- a/v2/tabler/dimensions.go
+++ b/v2/tabler/dimensions.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
 )
 
 type ComputeEnvs oapi.HTCProjectDimensions

--- a/v2/tabler/instant.go
+++ b/v2/tabler/instant.go
@@ -3,7 +3,7 @@ package tabler
 import (
 	"time"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
 )
 
 // Generic function for handling oapi.OptInstant, OptDateTime, and

--- a/v2/tabler/job.go
+++ b/v2/tabler/job.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
 )
 
 var htcJobFields = []Field{

--- a/v2/tabler/project.go
+++ b/v2/tabler/project.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
 )
 
 type HTCProjects []oapi.HTCProject

--- a/v2/tabler/task.go
+++ b/v2/tabler/task.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	oapi "github.com/rescale/htc-storage-cli/v2/api/_oas"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
 )
 
 type HTCTasks []oapi.HTCTask


### PR DESCRIPTION
commit 3286198af42edb8a3cfec9f04b2ff5c6903097c0
Author: Hunter Blanks <hblanks@rescale.com>
Date:   Mon Dec 30 21:38:22 2024 -0600

    Extend job get with --sort + --reverse (ENK-2349)
    
    Enable sorting by created, completed, and status, and support reversing,
    too.

commit eef30a8583b3c64a907bf2e906c37fb2532160eb
Author: Hunter Blanks <hblanks@rescale.com>
Date:   Mon Dec 30 22:55:02 2024 -0600

    commands: add headings for all top level commands (ENK-2353)
    
    * Fix incorect heading for version and add headings for remaining
      commands.
    * Clean up subcommands so they all go in commands/*/command.go

commit 97c63b0a5a62df167d3b7c2e0aa23e9d1b88f671
Author: Hunter Blanks <hblanks@rescale.com>
Date:   Tue Dec 31 00:22:36 2024 -0600

    job submit: document and give example using - for stdin (ENK-2352)
    
    Update `htc job submit`:
    
    * Use common.OpenArg() for its first argument.
    * Add sample JSON to usage string.
    * Update usage to note that '-' works for stdin.

commit 902f0bc1b26eec23cd1603d8c598c703990a99ea
Author: Hunter Blanks <hblanks@rescale.com>
Date:   Fri Dec 20 12:26:21 2024 -0600

    update project get usage string and TODO

commit 497609b1409ebe9f04499e3b3ef833e2dfe4e880
Author: Hunter Blanks <hblanks@rescale.com>
Date:   Fri Jan 3 14:19:55 2025 -0800

    v2/CHANGES.md: prep v0.0.8 release

commit 22928cca1ecaf2f998728ebada44ea413985f021
Author: Hunter Blanks <hblanks@rescale.com>
Date:   Mon Jan 6 11:26:01 2025 -0800

    .github: remove extraneous `go get` and only build v2

commit ffc0feadbcee87b95d01846ae9342c5b04ba9caf
Author: Hunter Blanks <hblanks@rescale.com>
Date:   Mon Jan 6 11:27:33 2025 -0800

    go.mod et al: updatego package to rescale-labs/htc-cli
    
    (and remove target for uploading binaries to S3)
