### PR TITLE
ENK-2401: add -e for env vars

### DIFF
--- a/v2/commands/job/submit.go
+++ b/v2/commands/job/submit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/rescale-labs/htc-cli/v2/config"
 	"os"
 	"strings"
 	"time"
@@ -13,6 +12,7 @@ import (
 
 	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
 	"github.com/rescale-labs/htc-cli/v2/common"
+	"github.com/rescale-labs/htc-cli/v2/config"
 )
 
 type submitRequest struct {


### PR DESCRIPTION
https://rescale.atlassian.net/browse/ENK-2401 


Tested on local build:
```
~/IdeaProjects/enki/definitions/HTCCLI/ENK-2382$ htc job submit j_def.json --env=env1=dead,env2=beef
[
  {
    "batchSize": 1,
    "cloudProvider": "UNASSIGNED",
    "createdBy": "gxkSa",
    "experimental": {
      "cloudFileSystems": false,
      "kubernetesSwap": false
    },
    "group": "",
    "htcJobDefinition": {
      "architecture": "X86",
      "claims": [],
      "commands": [
        "sleep",
        "3600"
      ],
      "envs": [
        {
          "name": "env1",
          "value": "dead"
        },
        {
          "name": "env2",
          "value": "beef"
        }
      ],
      "execTimeoutSeconds": 5000,
      "imageName": "enk-2382:latest",
      "maxDiskGiB": 0,
      "maxMemory": 64,
      "maxSwap": 2000,
      "maxVCpus": 1,
      "priority": "ON_DEMAND_ECONOMY",
      "tags": {}
    },
    "jobDefinitionName": "152be5e9-a29e-4f35-a177-d291131c12ab-a46031bd-ce35-4b80-b2de-e1bdc1decddc",
    "jobName": "testing-labels",
    "parentJobId": "a46031bd-ce35-4b80-b2de-e1bdc1decddc",
    "projectId": "6e688f40-5e37-4e04-9a40-13105a623778",
    "rescaleProjectId": null,
    "rescaleTimeReceived": "2025-01-30T17:28:55Z",
    "tags": [],
    "taskId": "152be5e9-a29e-4f35-a177-d291131c12ab",
    "workspaceId": "04-875358043"
  }
]
```