### PR TITLE
ENK-2350: adding filter to be used together with --latest

### DIFF
--- a/v2/api/_oas/oas_response_decoders_gen.go
+++ b/v2/api/_oas/oas_response_decoders_gen.go
@@ -643,6 +643,41 @@ func decodeGetJobsResponse(resp *http.Response) (res GetJobsRes, _ error) {
 	case 403:
 		// Code 403.
 		return &GetJobsForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response HTCRequestError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }

--- a/v2/api/_oas/oas_response_encoders_gen.go
+++ b/v2/api/_oas/oas_response_encoders_gen.go
@@ -334,6 +334,18 @@ func encodeGetJobsResponse(response GetJobsRes, w http.ResponseWriter) error {
 
 		return nil
 
+	case *HTCRequestError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}

--- a/v2/api/_oas/oas_schemas_gen.go
+++ b/v2/api/_oas/oas_schemas_gen.go
@@ -3101,6 +3101,7 @@ func (s *HTCRequestError) SetMessage(val OptNilString) {
 
 func (*HTCRequestError) createProjectRes() {}
 func (*HTCRequestError) getJobRes()        {}
+func (*HTCRequestError) getJobsRes()       {}
 func (*HTCRequestError) getLogsRes()       {}
 func (*HTCRequestError) submitJobsRes()    {}
 

--- a/v2/api/swagger-patched.json
+++ b/v2/api/swagger-patched.json
@@ -3929,6 +3929,15 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/HTCRequestError"
+                        }
+                     }
+                  }
                }
             },
             "security": [

--- a/v2/api/swagger.jsonnet
+++ b/v2/api/swagger.jsonnet
@@ -169,6 +169,13 @@ local patches = {
               },
             },
           },
+          '404'+: {
+            content+: {
+              'application/json'+: {
+                schema: { '$ref': '#/components/schemas/HTCRequestError' },
+              },
+            },
+          }
         },
       },
     },

--- a/v2/commands/job/get.go
+++ b/v2/commands/job/get.go
@@ -152,7 +152,8 @@ func Get(cmd *cobra.Command, args []string) error {
 			panic("Unrecognized sort option")
 		}
 
-		if reverse {
+		// When using latest flag we always want to reverse the order to get latest jobs
+		if reverse || (latest > 0) {
 			oldFunc := sortFunc
 			sortFunc = func(a, b oapi.HTCJob) int {
 				return -1 * oldFunc(a, b)
@@ -192,7 +193,7 @@ func init() {
 	flags := GetCmd.Flags()
 
 	flags.IntP("limit", "l", 0, "Limit response from API to N items. Use for tasks with large # of jobs")
-	flags.IntP("latest", "", 0, "Cannot be used together with limit. Get latest N jobs in a task. This option can be combined with filter, sort and reverse.")
+	flags.IntP("latest", "", 0, "Cannot be used together with limit. Get latest N jobs in a task. This option can be combined with sort and filter.")
 	flags.String("project-id", "", "HTC project ID")
 	flags.String("task-id", "", "HTC task ID")
 	flags.String("group", "", "HTC job batch group")

--- a/v2/common/vartypes.go
+++ b/v2/common/vartypes.go
@@ -1,0 +1,82 @@
+package common
+
+import (
+	"fmt"
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"strings"
+)
+
+type SortOrder string
+
+const (
+	SortCompleted SortOrder = "completed"
+	SortCreated   SortOrder = "created"
+	SortStatus    SortOrder = "status"
+)
+
+func (s *SortOrder) String() string {
+	return string(*s)
+}
+
+func (s *SortOrder) Set(v string) error {
+	switch SortOrder(v) {
+	case SortCompleted, SortCreated, SortStatus:
+		*s = SortOrder(v)
+		return nil
+	default:
+		return fmt.Errorf("%q is not a valid sort option", v)
+	}
+}
+
+func (s *SortOrder) Type() string {
+	return "string"
+}
+
+// Derived type
+type StatusFilter oapi.RescaleJobStatus
+
+// Implement the flag.Value interface for StatusFilter
+func (sf *StatusFilter) String() string {
+	return string(*sf)
+}
+
+func (s *StatusFilter) Set(val string) error {
+	val = strings.ToUpper(val) // Case-insensitive
+	switch val {
+	case string(oapi.RescaleJobStatusSUBMITTEDTORESCALE):
+		*s = StatusFilter(oapi.RescaleJobStatusSUBMITTEDTORESCALE) // Conversion
+		return nil
+	case string(oapi.RescaleJobStatusSUBMITTEDTOPROVIDER):
+		*s = StatusFilter(oapi.RescaleJobStatusSUBMITTEDTOPROVIDER) // Conversion
+		return nil
+	case string(oapi.RescaleJobStatusRUNNABLE):
+		*s = StatusFilter(oapi.RescaleJobStatusRUNNABLE) // Conversion
+		return nil
+	case string(oapi.RescaleJobStatusSTARTING):
+		*s = StatusFilter(oapi.RescaleJobStatusSTARTING) // Conversion
+		return nil
+	case string(oapi.RescaleJobStatusRUNNING):
+		*s = StatusFilter(oapi.RescaleJobStatusRUNNING) // Conversion
+		return nil
+	case string(oapi.RescaleJobStatusSUCCEEDED):
+		*s = StatusFilter(oapi.RescaleJobStatusSUCCEEDED) // Conversion
+		return nil
+	case string(oapi.RescaleJobStatusFAILED):
+		*s = StatusFilter(oapi.RescaleJobStatusFAILED) // Conversion
+		return nil
+	default:
+		panic("Unknown Rescale job status for filtering!")
+	}
+}
+
+func (sf *StatusFilter) Type() string {
+	return "StatusFilter"
+}
+
+func (sf StatusFilter) ToRescaleStatus() oapi.RescaleJobStatus {
+	return oapi.RescaleJobStatus(sf)
+}
+
+func ToStatusFilter(rjs oapi.RescaleJobStatus) StatusFilter {
+	return StatusFilter(rjs)
+}


### PR DESCRIPTION
1. With 63fc473a0074be55c79b58aa608964a390a1c263 the --latest functionality is truly complete. User can now filter by status and combine it with --sort and --latest option get some last run job ids. To get full description just use the -ojson.

Intended usage example:
```
htc job get --project-id cba12315-1c70-4720-939e-0164fa90b562 --task-id 0ac405e7-0586-4345-a67c-138211f0cb05 --latest 1 --filter SUCCEEDED -ojson
```
