### PR TITLE
ENK-2441: add `-f` flag to follow logs

### DIFF
--- a/v2/api/_oas/oas_json_gen.go
+++ b/v2/api/_oas/oas_json_gen.go
@@ -14,6 +14,50 @@ import (
 	"github.com/ogen-go/ogen/validate"
 )
 
+// Encode implements json.Marshaler.
+func (s *AlgorithmParameterSpec) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *AlgorithmParameterSpec) encodeFields(e *jx.Encoder) {
+}
+
+var jsonFieldsNameOfAlgorithmParameterSpec = [0]string{}
+
+// Decode decodes AlgorithmParameterSpec from json.
+func (s *AlgorithmParameterSpec) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AlgorithmParameterSpec to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		default:
+			return d.Skip()
+		}
+	}); err != nil {
+		return errors.Wrap(err, "decode AlgorithmParameterSpec")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AlgorithmParameterSpec) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AlgorithmParameterSpec) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes Architecture as json.
 func (s Architecture) Encode(e *jx.Encoder) {
 	e.Str(string(s))
@@ -223,6 +267,8 @@ func (s *CloudProvider) Decode(d *jx.Decoder) error {
 		*s = CloudProviderAZURE
 	case CloudProviderRC:
 		*s = CloudProviderRC
+	case CloudProviderCOREWEAVE:
+		*s = CloudProviderCOREWEAVE
 	case CloudProviderUNASSIGNED:
 		*s = CloudProviderUNASSIGNED
 	default:
@@ -460,6 +506,12 @@ func (s *ExperimentalFields) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.PrivilegedMode.Set {
+			e.FieldStart("privilegedMode")
+			s.PrivilegedMode.Encode(e)
+		}
+	}
+	{
 		if s.RescaleFilesRDFAgent.Set {
 			e.FieldStart("rescaleFilesRDFAgent")
 			s.RescaleFilesRDFAgent.Encode(e)
@@ -467,10 +519,11 @@ func (s *ExperimentalFields) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfExperimentalFields = [3]string{
+var jsonFieldsNameOfExperimentalFields = [4]string{
 	0: "cloudFileSystems",
 	1: "kubernetesSwap",
-	2: "rescaleFilesRDFAgent",
+	2: "privilegedMode",
+	3: "rescaleFilesRDFAgent",
 }
 
 // Decode decodes ExperimentalFields from json.
@@ -500,6 +553,16 @@ func (s *ExperimentalFields) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"kubernetesSwap\"")
+			}
+		case "privilegedMode":
+			if err := func() error {
+				s.PrivilegedMode.Reset()
+				if err := s.PrivilegedMode.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"privilegedMode\"")
 			}
 		case "rescaleFilesRDFAgent":
 			if err := func() error {
@@ -1435,6 +1498,8 @@ func (s *HTCComputeEnvironmentRegion) Decode(d *jx.Decoder) error {
 		*s = HTCComputeEnvironmentRegionAZUREEUNORTH
 	case HTCComputeEnvironmentRegionRCICELAND1:
 		*s = HTCComputeEnvironmentRegionRCICELAND1
+	case HTCComputeEnvironmentRegionCOREWEAVEUSEAST4:
+		*s = HTCComputeEnvironmentRegionCOREWEAVEUSEAST4
 	case HTCComputeEnvironmentRegionUNASSIGNED:
 		*s = HTCComputeEnvironmentRegionUNASSIGNED
 	default:
@@ -1824,6 +1889,12 @@ func (s *HTCJob) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.MaxGpus.Set {
+			e.FieldStart("maxGpus")
+			s.MaxGpus.Encode(e)
+		}
+	}
+	{
 		if s.MaxMemory.Set {
 			e.FieldStart("maxMemory")
 			s.MaxMemory.Encode(e)
@@ -1913,7 +1984,7 @@ func (s *HTCJob) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfHTCJob = [30]string{
+var jsonFieldsNameOfHTCJob = [31]string{
 	0:  "architecture",
 	1:  "commands",
 	2:  "completedAt",
@@ -1930,20 +2001,21 @@ var jsonFieldsNameOfHTCJob = [30]string{
 	13: "jobExecutionEnvironment",
 	14: "jobUUID",
 	15: "maxDiskGiB",
-	16: "maxMemory",
-	17: "maxSwap",
-	18: "maxVCpus",
-	19: "minVCpus",
-	20: "projectId",
-	21: "providerJobId",
-	22: "region",
-	23: "startedAt",
-	24: "status",
-	25: "statusReason",
-	26: "tags",
-	27: "taskId",
-	28: "updatedAt",
-	29: "workspaceId",
+	16: "maxGpus",
+	17: "maxMemory",
+	18: "maxSwap",
+	19: "maxVCpus",
+	20: "minVCpus",
+	21: "projectId",
+	22: "providerJobId",
+	23: "region",
+	24: "startedAt",
+	25: "status",
+	26: "statusReason",
+	27: "tags",
+	28: "taskId",
+	29: "updatedAt",
+	30: "workspaceId",
 }
 
 // Decode decodes HTCJob from json.
@@ -2131,6 +2203,16 @@ func (s *HTCJob) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"maxDiskGiB\"")
+			}
+		case "maxGpus":
+			if err := func() error {
+				s.MaxGpus.Reset()
+				if err := s.MaxGpus.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"maxGpus\"")
 			}
 		case "maxMemory":
 			if err := func() error {
@@ -2349,16 +2431,6 @@ func (s *HTCJobDefinition) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.SecretEnvs != nil {
-			e.FieldStart("secretEnvs")
-			e.ArrStart()
-			for _, elem := range s.SecretEnvs {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
-		}
-	}
-	{
 		if s.ExecTimeoutSeconds.Set {
 			e.FieldStart("execTimeoutSeconds")
 			s.ExecTimeoutSeconds.Encode(e)
@@ -2412,21 +2484,20 @@ func (s *HTCJobDefinition) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfHTCJobDefinition = [14]string{
+var jsonFieldsNameOfHTCJobDefinition = [13]string{
 	0:  "architecture",
 	1:  "claims",
 	2:  "commands",
 	3:  "envs",
-	4:  "secretEnvs",
-	5:  "execTimeoutSeconds",
-	6:  "imageName",
-	7:  "maxDiskGiB",
-	8:  "maxMemory",
-	9:  "maxSwap",
-	10: "maxVCpus",
-	11: "priority",
-	12: "tags",
-	13: "workingDir",
+	4:  "execTimeoutSeconds",
+	5:  "imageName",
+	6:  "maxDiskGiB",
+	7:  "maxMemory",
+	8:  "maxSwap",
+	9:  "maxVCpus",
+	10: "priority",
+	11: "tags",
+	12: "workingDir",
 }
 
 // Decode decodes HTCJobDefinition from json.
@@ -2486,9 +2557,9 @@ func (s *HTCJobDefinition) Decode(d *jx.Decoder) error {
 			}
 		case "envs":
 			if err := func() error {
-				s.Envs = make([]EnvPair, 0)
+				s.Envs = make([]HTCJobDefinitionEnvsItem, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem EnvPair
+					var elem HTCJobDefinitionEnvsItem
 					if err := elem.Decode(d); err != nil {
 						return err
 					}
@@ -2501,23 +2572,6 @@ func (s *HTCJobDefinition) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"envs\"")
 			}
-		case "secretEnvs":
-			if err := func() error {
-				s.SecretEnvs = make([]SecretEnvPair, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem SecretEnvPair
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.SecretEnvs = append(s.SecretEnvs, elem)
-					return nil
-				}); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"secretEnvs\"")
-			}
 		case "execTimeoutSeconds":
 			if err := func() error {
 				s.ExecTimeoutSeconds.Reset()
@@ -2529,7 +2583,7 @@ func (s *HTCJobDefinition) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"execTimeoutSeconds\"")
 			}
 		case "imageName":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.ImageName = string(v)
@@ -2620,7 +2674,7 @@ func (s *HTCJobDefinition) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
-		0b01000000,
+		0b00100000,
 		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
@@ -2663,6 +2717,159 @@ func (s *HTCJobDefinition) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *HTCJobDefinition) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *HTCJobDefinitionEnvsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *HTCJobDefinitionEnvsItem) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("name")
+		e.Str(s.Name)
+	}
+	{
+		e.FieldStart("value")
+		e.Str(s.Value)
+	}
+}
+
+var jsonFieldsNameOfHTCJobDefinitionEnvsItem = [2]string{
+	0: "name",
+	1: "value",
+}
+
+// Decode decodes HTCJobDefinitionEnvsItem from json.
+func (s *HTCJobDefinitionEnvsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode HTCJobDefinitionEnvsItem to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "name":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Name = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"name\"")
+			}
+		case "value":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.Value = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"value\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode HTCJobDefinitionEnvsItem")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfHTCJobDefinitionEnvsItem) {
+					name = jsonFieldsNameOfHTCJobDefinitionEnvsItem[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *HTCJobDefinitionEnvsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *HTCJobDefinitionEnvsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes HTCJobDefinitionPriority as json.
+func (s HTCJobDefinitionPriority) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes HTCJobDefinitionPriority from json.
+func (s *HTCJobDefinitionPriority) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode HTCJobDefinitionPriority to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch HTCJobDefinitionPriority(v) {
+	case HTCJobDefinitionPriorityONDEMANDPRIORITY:
+		*s = HTCJobDefinitionPriorityONDEMANDPRIORITY
+	case HTCJobDefinitionPriorityONDEMANDECONOMY:
+		*s = HTCJobDefinitionPriorityONDEMANDECONOMY
+	default:
+		*s = HTCJobDefinitionPriority(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s HTCJobDefinitionPriority) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *HTCJobDefinitionPriority) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -4926,6 +5133,8 @@ func (s *HTCRegionAdminSettingsRegion) Decode(d *jx.Decoder) error {
 		*s = HTCRegionAdminSettingsRegionAZUREEUNORTH
 	case HTCRegionAdminSettingsRegionRCICELAND1:
 		*s = HTCRegionAdminSettingsRegionRCICELAND1
+	case HTCRegionAdminSettingsRegionCOREWEAVEUSEAST4:
+		*s = HTCRegionAdminSettingsRegionCOREWEAVEUSEAST4
 	case HTCRegionAdminSettingsRegionUNASSIGNED:
 		*s = HTCRegionAdminSettingsRegionUNASSIGNED
 	default:
@@ -7242,46 +7451,6 @@ func (s *JobExecutionEnvironment) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes JobPriority as json.
-func (s JobPriority) Encode(e *jx.Encoder) {
-	e.Str(string(s))
-}
-
-// Decode decodes JobPriority from json.
-func (s *JobPriority) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode JobPriority to nil")
-	}
-	v, err := d.StrBytes()
-	if err != nil {
-		return err
-	}
-	// Try to use constant string.
-	switch JobPriority(v) {
-	case JobPriorityONDEMANDPRIORITY:
-		*s = JobPriorityONDEMANDPRIORITY
-	case JobPriorityONDEMANDECONOMY:
-		*s = JobPriorityONDEMANDECONOMY
-	default:
-		*s = JobPriority(v)
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s JobPriority) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *JobPriority) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode implements json.Marshaler.
 func (s *JsonWebKey) Encode(e *jx.Encoder) {
 	e.ObjStart()
@@ -8649,6 +8818,39 @@ func (s *OptHTCComputeEnvironmentRegion) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes HTCJobDefinitionPriority as json.
+func (o OptHTCJobDefinitionPriority) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Str(string(o.Value))
+}
+
+// Decode decodes HTCJobDefinitionPriority from json.
+func (o *OptHTCJobDefinitionPriority) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptHTCJobDefinitionPriority to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptHTCJobDefinitionPriority) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptHTCJobDefinitionPriority) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes HTCJobDefinitionTags as json.
 func (o OptHTCJobDefinitionTags) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -9211,39 +9413,6 @@ func (s OptJobExecutionEnvironment) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptJobExecutionEnvironment) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes JobPriority as json.
-func (o OptJobPriority) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	e.Str(string(o.Value))
-}
-
-// Decode decodes JobPriority from json.
-func (o *OptJobPriority) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptJobPriority to nil")
-	}
-	o.Set = true
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptJobPriority) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptJobPriority) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -10405,12 +10574,19 @@ func (s *PublicKey) encodeFields(e *jx.Encoder) {
 			s.Format.Encode(e)
 		}
 	}
+	{
+		if s.Params != nil {
+			e.FieldStart("params")
+			s.Params.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfPublicKey = [3]string{
+var jsonFieldsNameOfPublicKey = [4]string{
 	0: "algorithm",
 	1: "encoded",
 	2: "format",
+	3: "params",
 }
 
 // Decode decodes PublicKey from json.
@@ -10450,6 +10626,18 @@ func (s *PublicKey) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"format\"")
+			}
+		case "params":
+			if err := func() error {
+				s.Params = nil
+				var elem AlgorithmParameterSpec
+				if err := elem.Decode(d); err != nil {
+					return err
+				}
+				s.Params = &elem
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"params\"")
 			}
 		default:
 			return d.Skip()
@@ -11058,6 +11246,8 @@ func (s *RescaleRegion) Decode(d *jx.Decoder) error {
 		*s = RescaleRegionAZUREEUNORTH
 	case RescaleRegionRCICELAND1:
 		*s = RescaleRegionRCICELAND1
+	case RescaleRegionCOREWEAVEUSEAST4:
+		*s = RescaleRegionCOREWEAVEUSEAST4
 	case RescaleRegionUNASSIGNED:
 		*s = RescaleRegionUNASSIGNED
 	default:
@@ -11343,119 +11533,6 @@ func (s *RescaleUser) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *RescaleUser) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s *SecretEnvPair) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields encodes fields.
-func (s *SecretEnvPair) encodeFields(e *jx.Encoder) {
-	{
-		e.FieldStart("name")
-		e.Str(s.Name)
-	}
-	{
-		e.FieldStart("value")
-		e.Str(s.Value)
-	}
-}
-
-var jsonFieldsNameOfSecretEnvPair = [2]string{
-	0: "name",
-	1: "value",
-}
-
-// Decode decodes SecretEnvPair from json.
-func (s *SecretEnvPair) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode SecretEnvPair to nil")
-	}
-	var requiredBitSet [1]uint8
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "name":
-			requiredBitSet[0] |= 1 << 0
-			if err := func() error {
-				v, err := d.Str()
-				s.Name = string(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"name\"")
-			}
-		case "value":
-			requiredBitSet[0] |= 1 << 1
-			if err := func() error {
-				v, err := d.Str()
-				s.Value = string(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"value\"")
-			}
-		default:
-			return d.Skip()
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode SecretEnvPair")
-	}
-	// Validate required fields.
-	var failures []validate.FieldError
-	for i, mask := range [1]uint8{
-		0b00000011,
-	} {
-		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
-			// Mask only required fields and check equality to mask using XOR.
-			//
-			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
-			// Bits of fields which would be set are actually bits of missed fields.
-			missed := bits.OnesCount8(result)
-			for bitN := 0; bitN < missed; bitN++ {
-				bitIdx := bits.TrailingZeros8(result)
-				fieldIdx := i*8 + bitIdx
-				var name string
-				if fieldIdx < len(jsonFieldsNameOfSecretEnvPair) {
-					name = jsonFieldsNameOfSecretEnvPair[fieldIdx]
-				} else {
-					name = strconv.Itoa(fieldIdx)
-				}
-				failures = append(failures, validate.FieldError{
-					Name:  name,
-					Error: validate.ErrFieldRequired,
-				})
-				// Reset bit.
-				result &^= 1 << bitIdx
-			}
-		}
-	}
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s *SecretEnvPair) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *SecretEnvPair) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/v2/api/_oas/oas_json_gen.go
+++ b/v2/api/_oas/oas_json_gen.go
@@ -14,50 +14,6 @@ import (
 	"github.com/ogen-go/ogen/validate"
 )
 
-// Encode implements json.Marshaler.
-func (s *AlgorithmParameterSpec) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields encodes fields.
-func (s *AlgorithmParameterSpec) encodeFields(e *jx.Encoder) {
-}
-
-var jsonFieldsNameOfAlgorithmParameterSpec = [0]string{}
-
-// Decode decodes AlgorithmParameterSpec from json.
-func (s *AlgorithmParameterSpec) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode AlgorithmParameterSpec to nil")
-	}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		default:
-			return d.Skip()
-		}
-	}); err != nil {
-		return errors.Wrap(err, "decode AlgorithmParameterSpec")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s *AlgorithmParameterSpec) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AlgorithmParameterSpec) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes Architecture as json.
 func (s Architecture) Encode(e *jx.Encoder) {
 	e.Str(string(s))
@@ -10574,19 +10530,12 @@ func (s *PublicKey) encodeFields(e *jx.Encoder) {
 			s.Format.Encode(e)
 		}
 	}
-	{
-		if s.Params != nil {
-			e.FieldStart("params")
-			s.Params.Encode(e)
-		}
-	}
 }
 
-var jsonFieldsNameOfPublicKey = [4]string{
+var jsonFieldsNameOfPublicKey = [3]string{
 	0: "algorithm",
 	1: "encoded",
 	2: "format",
-	3: "params",
 }
 
 // Decode decodes PublicKey from json.
@@ -10626,18 +10575,6 @@ func (s *PublicKey) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"format\"")
-			}
-		case "params":
-			if err := func() error {
-				s.Params = nil
-				var elem AlgorithmParameterSpec
-				if err := elem.Decode(d); err != nil {
-					return err
-				}
-				s.Params = &elem
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"params\"")
 			}
 		default:
 			return d.Skip()

--- a/v2/api/_oas/oas_parameters_gen.go
+++ b/v2/api/_oas/oas_parameters_gen.go
@@ -1339,6 +1339,8 @@ type GetLogsParams struct {
 	PageIndex OptString
 	// Maximum value: 10000.
 	PageSize OptInt32
+	// Sort order.
+	Sort OptGetLogsSort
 }
 
 func unpackGetLogsParams(packed middleware.Parameters) (params GetLogsParams) {
@@ -1379,6 +1381,15 @@ func unpackGetLogsParams(packed middleware.Parameters) (params GetLogsParams) {
 		}
 		if v, ok := packed[key]; ok {
 			params.PageSize = v.(OptInt32)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "sort",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Sort = v.(OptGetLogsSort)
 		}
 	}
 	return params
@@ -1604,6 +1615,67 @@ func decodeGetLogsParams(args [3]string, argsEscaped bool, r *http.Request) (par
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "pageSize",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Set default value for query: sort.
+	{
+		val := GetLogsSort("desc")
+		params.Sort.SetTo(val)
+	}
+	// Decode query: sort.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "sort",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotSortVal GetLogsSort
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotSortVal = GetLogsSort(c)
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Sort.SetTo(paramsDotSortVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := func() error {
+				if value, ok := params.Sort.Get(); ok {
+					if err := func() error {
+						if err := value.Validate(); err != nil {
+							return err
+						}
+						return nil
+					}(); err != nil {
+						return err
+					}
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "sort",
 			In:   "query",
 			Err:  err,
 		}
@@ -2159,6 +2231,73 @@ func decodeGetTasksParams(args [1]string, argsEscaped bool, r *http.Request) (pa
 		return params, &ogenerrors.DecodeParamError{
 			Name: "pageSize",
 			In:   "query",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
+// GetTokenParams is parameters of getToken operation.
+type GetTokenParams struct {
+	XRescaleEnvironment OptString
+}
+
+func unpackGetTokenParams(packed middleware.Parameters) (params GetTokenParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "X-Rescale-Environment",
+			In:   "header",
+		}
+		if v, ok := packed[key]; ok {
+			params.XRescaleEnvironment = v.(OptString)
+		}
+	}
+	return params
+}
+
+func decodeGetTokenParams(args [0]string, argsEscaped bool, r *http.Request) (params GetTokenParams, _ error) {
+	h := uri.NewHeaderDecoder(r.Header)
+	// Set default value for header: X-Rescale-Environment.
+	{
+		val := string("prod")
+		params.XRescaleEnvironment.SetTo(val)
+	}
+	// Decode header: X-Rescale-Environment.
+	if err := func() error {
+		cfg := uri.HeaderParameterDecodingConfig{
+			Name:    "X-Rescale-Environment",
+			Explode: false,
+		}
+		if err := h.HasParam(cfg); err == nil {
+			if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotXRescaleEnvironmentVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotXRescaleEnvironmentVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.XRescaleEnvironment.SetTo(paramsDotXRescaleEnvironmentVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "X-Rescale-Environment",
+			In:   "header",
 			Err:  err,
 		}
 	}

--- a/v2/api/_oas/oas_response_decoders_gen.go
+++ b/v2/api/_oas/oas_response_decoders_gen.go
@@ -108,6 +108,9 @@ func decodeCancelJobsResponse(resp *http.Response) (res CancelJobsRes, _ error) 
 	case 403:
 		// Code 403.
 		return &CancelJobsForbidden{}, nil
+	case 404:
+		// Code 404.
+		return &CancelJobsNotFound{}, nil
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -246,6 +249,41 @@ func decodeCreateRepoResponse(resp *http.Response) (res CreateRepoRes, _ error) 
 	case 403:
 		// Code 403.
 		return &CreateRepoForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -302,6 +340,41 @@ func decodeCreateTaskResponse(resp *http.Response) (res CreateTaskRes, _ error) 
 	case 403:
 		// Code 403.
 		return &CreateTaskForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -358,6 +431,41 @@ func decodeGetDimensionsResponse(resp *http.Response) (res GetDimensionsRes, _ e
 	case 403:
 		// Code 403.
 		return &GetDimensionsForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -496,6 +604,41 @@ func decodeGetImagesResponse(resp *http.Response) (res GetImagesRes, _ error) {
 	case 403:
 		// Code 403.
 		return &GetImagesForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -734,6 +877,41 @@ func decodeGetLimitsResponse(resp *http.Response) (res GetLimitsRes, _ error) {
 	case 403:
 		// Code 403.
 		return &GetLimitsForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -903,6 +1081,41 @@ func decodeGetProjectResponse(resp *http.Response) (res GetProjectRes, _ error) 
 	case 403:
 		// Code 403.
 		return &GetProjectForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1025,6 +1238,41 @@ func decodeGetRegistryTokenResponse(resp *http.Response) (res GetRegistryTokenRe
 	case 403:
 		// Code 403.
 		return &GetRegistryTokenForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1081,6 +1329,41 @@ func decodeGetTasksResponse(resp *http.Response) (res GetTasksRes, _ error) {
 	case 403:
 		// Code 403.
 		return &GetTasksForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1304,6 +1587,41 @@ func decodeHtcProjectsProjectIdDimensionsPutResponse(resp *http.Response) (res H
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdDimensionsPutForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1319,6 +1637,41 @@ func decodeHtcProjectsProjectIdLimitsDeleteResponse(resp *http.Response) (res Ht
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdLimitsDeleteForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1334,6 +1687,41 @@ func decodeHtcProjectsProjectIdLimitsIDDeleteResponse(resp *http.Response) (res 
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdLimitsIDDeleteForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1390,6 +1778,41 @@ func decodeHtcProjectsProjectIdLimitsIDGetResponse(resp *http.Response) (res Htc
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdLimitsIDGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1446,6 +1869,41 @@ func decodeHtcProjectsProjectIdLimitsIDPatchResponse(resp *http.Response) (res H
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdLimitsIDPatchForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1502,6 +1960,41 @@ func decodeHtcProjectsProjectIdLimitsPostResponse(resp *http.Response) (res HtcP
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdLimitsPostForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1558,6 +2051,41 @@ func decodeHtcProjectsProjectIdPatchResponse(resp *http.Response) (res HtcProjec
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdPatchForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1614,6 +2142,41 @@ func decodeHtcProjectsProjectIdStoragePresignedURLGetResponse(resp *http.Respons
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdStoragePresignedURLGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1670,6 +2233,41 @@ func decodeHtcProjectsProjectIdStorageTokenGetResponse(resp *http.Response) (res
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdStorageTokenGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1726,6 +2324,41 @@ func decodeHtcProjectsProjectIdStorageTokenRegionGetResponse(resp *http.Response
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdStorageTokenRegionGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1782,6 +2415,41 @@ func decodeHtcProjectsProjectIdStorageTokensGetResponse(resp *http.Response) (re
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdStorageTokensGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1797,6 +2465,41 @@ func decodeHtcProjectsProjectIdTaskRetentionPolicyDeleteResponse(resp *http.Resp
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTaskRetentionPolicyDeleteForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1853,6 +2556,41 @@ func decodeHtcProjectsProjectIdTaskRetentionPolicyGetResponse(resp *http.Respons
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTaskRetentionPolicyGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1909,6 +2647,41 @@ func decodeHtcProjectsProjectIdTaskRetentionPolicyPutResponse(resp *http.Respons
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTaskRetentionPolicyPutForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -1965,6 +2738,41 @@ func decodeHtcProjectsProjectIdTasksTaskIdDeleteResponse(resp *http.Response) (r
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTasksTaskIdDeleteForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2021,6 +2829,41 @@ func decodeHtcProjectsProjectIdTasksTaskIdGetResponse(resp *http.Response) (res 
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTasksTaskIdGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2068,6 +2911,41 @@ func decodeHtcProjectsProjectIdTasksTaskIdGroupSummaryStatisticsGetResponse(resp
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTasksTaskIdGroupSummaryStatisticsGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2124,6 +3002,41 @@ func decodeHtcProjectsProjectIdTasksTaskIdGroupsGetResponse(resp *http.Response)
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTasksTaskIdGroupsGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2171,6 +3084,41 @@ func decodeHtcProjectsProjectIdTasksTaskIdJobsJobIdEventsGetResponse(resp *http.
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTasksTaskIdJobsJobIdEventsGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2227,6 +3175,41 @@ func decodeHtcProjectsProjectIdTasksTaskIdPatchResponse(resp *http.Response) (re
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTasksTaskIdPatchForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2283,6 +3266,41 @@ func decodeHtcProjectsProjectIdTasksTaskIdStoragePresignedURLGetResponse(resp *h
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTasksTaskIdStoragePresignedURLGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2339,6 +3357,41 @@ func decodeHtcProjectsProjectIdTasksTaskIdStorageRegionalStorageGetResponse(resp
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTasksTaskIdStorageRegionalStorageGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2395,6 +3448,41 @@ func decodeHtcProjectsProjectIdTasksTaskIdStorageTokenGetResponse(resp *http.Res
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTasksTaskIdStorageTokenGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2451,6 +3539,41 @@ func decodeHtcProjectsProjectIdTasksTaskIdStorageTokenRegionGetResponse(resp *ht
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTasksTaskIdStorageTokenRegionGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2507,6 +3630,41 @@ func decodeHtcProjectsProjectIdTasksTaskIdStorageTokensGetResponse(resp *http.Re
 	case 403:
 		// Code 403.
 		return &HtcProjectsProjectIdTasksTaskIdStorageTokensGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2801,6 +3959,41 @@ func decodeHtcStorageRegionRegionGetResponse(resp *http.Response) (res HtcStorag
 	case 403:
 		// Code 403.
 		return &HtcStorageRegionRegionGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2857,6 +4050,41 @@ func decodeHtcWorkspacesWorkspaceIdDimensionsGetResponse(resp *http.Response) (r
 	case 403:
 		// Code 403.
 		return &HtcWorkspacesWorkspaceIdDimensionsGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2913,6 +4141,41 @@ func decodeHtcWorkspacesWorkspaceIdLimitsGetResponse(resp *http.Response) (res H
 	case 403:
 		// Code 403.
 		return &HtcWorkspacesWorkspaceIdLimitsGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -2969,6 +4232,41 @@ func decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetResponse(resp *http.Res
 	case 403:
 		// Code 403.
 		return &HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -3025,6 +4323,41 @@ func decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutResponse(resp *http.Res
 	case 403:
 		// Code 403.
 		return &HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
@@ -3192,6 +4525,41 @@ func decodeSubmitJobsResponse(resp *http.Response) (res SubmitJobsRes, _ error) 
 	case 403:
 		// Code 403.
 		return &SubmitJobsForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }

--- a/v2/api/_oas/oas_response_encoders_gen.go
+++ b/v2/api/_oas/oas_response_encoders_gen.go
@@ -66,6 +66,11 @@ func encodeCancelJobsResponse(response CancelJobsRes, w http.ResponseWriter) err
 
 		return nil
 
+	case *CancelJobsNotFound:
+		w.WriteHeader(404)
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -136,6 +141,18 @@ func encodeCreateRepoResponse(response CreateRepoRes, w http.ResponseWriter) err
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -165,6 +182,18 @@ func encodeCreateTaskResponse(response CreateTaskRes, w http.ResponseWriter) err
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -191,6 +220,18 @@ func encodeGetDimensionsResponse(response GetDimensionsRes, w http.ResponseWrite
 
 	case *GetDimensionsForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -261,6 +302,18 @@ func encodeGetImagesResponse(response GetImagesRes, w http.ResponseWriter) error
 
 	case *GetImagesForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -375,6 +428,18 @@ func encodeGetLimitsResponse(response GetLimitsRes, w http.ResponseWriter) error
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -473,6 +538,18 @@ func encodeGetProjectResponse(response GetProjectRes, w http.ResponseWriter) err
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -545,6 +622,18 @@ func encodeGetRegistryTokenResponse(response GetRegistryTokenRes, w http.Respons
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -571,6 +660,18 @@ func encodeGetTasksResponse(response GetTasksRes, w http.ResponseWriter) error {
 
 	case *GetTasksForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -675,6 +776,18 @@ func encodeHtcProjectsProjectIdDimensionsPutResponse(response HtcProjectsProject
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -697,6 +810,18 @@ func encodeHtcProjectsProjectIdLimitsDeleteResponse(response HtcProjectsProjectI
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -716,6 +841,18 @@ func encodeHtcProjectsProjectIdLimitsIDDeleteResponse(response HtcProjectsProjec
 
 	case *HtcProjectsProjectIdLimitsIDDeleteForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -748,6 +885,18 @@ func encodeHtcProjectsProjectIdLimitsIDGetResponse(response HtcProjectsProjectId
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -774,6 +923,18 @@ func encodeHtcProjectsProjectIdLimitsIDPatchResponse(response HtcProjectsProject
 
 	case *HtcProjectsProjectIdLimitsIDPatchForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -806,6 +967,18 @@ func encodeHtcProjectsProjectIdLimitsPostResponse(response HtcProjectsProjectIdL
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -832,6 +1005,18 @@ func encodeHtcProjectsProjectIdPatchResponse(response HtcProjectsProjectIdPatchR
 
 	case *HtcProjectsProjectIdPatchForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -864,6 +1049,18 @@ func encodeHtcProjectsProjectIdStoragePresignedURLGetResponse(response HtcProjec
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -890,6 +1087,18 @@ func encodeHtcProjectsProjectIdStorageTokenGetResponse(response HtcProjectsProje
 
 	case *HtcProjectsProjectIdStorageTokenGetForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -922,6 +1131,18 @@ func encodeHtcProjectsProjectIdStorageTokenRegionGetResponse(response HtcProject
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -951,6 +1172,18 @@ func encodeHtcProjectsProjectIdStorageTokensGetResponse(response HtcProjectsProj
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -970,6 +1203,18 @@ func encodeHtcProjectsProjectIdTaskRetentionPolicyDeleteResponse(response HtcPro
 
 	case *HtcProjectsProjectIdTaskRetentionPolicyDeleteForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -1002,6 +1247,18 @@ func encodeHtcProjectsProjectIdTaskRetentionPolicyGetResponse(response HtcProjec
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -1028,6 +1285,18 @@ func encodeHtcProjectsProjectIdTaskRetentionPolicyPutResponse(response HtcProjec
 
 	case *HtcProjectsProjectIdTaskRetentionPolicyPutForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -1060,6 +1329,18 @@ func encodeHtcProjectsProjectIdTasksTaskIdDeleteResponse(response HtcProjectsPro
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -1086,6 +1367,18 @@ func encodeHtcProjectsProjectIdTasksTaskIdGetResponse(response HtcProjectsProjec
 
 	case *HtcProjectsProjectIdTasksTaskIdGetForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -1118,6 +1411,18 @@ func encodeHtcProjectsProjectIdTasksTaskIdGroupSummaryStatisticsGetResponse(resp
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -1144,6 +1449,18 @@ func encodeHtcProjectsProjectIdTasksTaskIdGroupsGetResponse(response HtcProjects
 
 	case *HtcProjectsProjectIdTasksTaskIdGroupsGetForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -1176,6 +1493,18 @@ func encodeHtcProjectsProjectIdTasksTaskIdJobsJobIdEventsGetResponse(response Ht
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -1202,6 +1531,18 @@ func encodeHtcProjectsProjectIdTasksTaskIdPatchResponse(response HtcProjectsProj
 
 	case *HtcProjectsProjectIdTasksTaskIdPatchForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -1234,6 +1575,18 @@ func encodeHtcProjectsProjectIdTasksTaskIdStoragePresignedURLGetResponse(respons
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -1260,6 +1613,18 @@ func encodeHtcProjectsProjectIdTasksTaskIdStorageRegionalStorageGetResponse(resp
 
 	case *HtcProjectsProjectIdTasksTaskIdStorageRegionalStorageGetForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -1292,6 +1657,18 @@ func encodeHtcProjectsProjectIdTasksTaskIdStorageTokenGetResponse(response HtcPr
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -1321,6 +1698,18 @@ func encodeHtcProjectsProjectIdTasksTaskIdStorageTokenRegionGetResponse(response
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -1347,6 +1736,18 @@ func encodeHtcProjectsProjectIdTasksTaskIdStorageTokensGetResponse(response HtcP
 
 	case *HtcProjectsProjectIdTasksTaskIdStorageTokensGetForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -1490,6 +1891,18 @@ func encodeHtcStorageRegionRegionGetResponse(response HtcStorageRegionRegionGetR
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -1516,6 +1929,18 @@ func encodeHtcWorkspacesWorkspaceIdDimensionsGetResponse(response HtcWorkspacesW
 
 	case *HtcWorkspacesWorkspaceIdDimensionsGetForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -1548,6 +1973,18 @@ func encodeHtcWorkspacesWorkspaceIdLimitsGetResponse(response HtcWorkspacesWorks
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -1577,6 +2014,18 @@ func encodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetResponse(response HtcWo
 
 		return nil
 
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -1603,6 +2052,18 @@ func encodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutResponse(response HtcWo
 
 	case *HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 
@@ -1675,6 +2136,18 @@ func encodeSubmitJobsResponse(response SubmitJobsRes, w http.ResponseWriter) err
 
 	case *SubmitJobsForbidden:
 		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
 
 		return nil
 

--- a/v2/api/_oas/oas_schemas_gen.go
+++ b/v2/api/_oas/oas_schemas_gen.go
@@ -11,6 +11,9 @@ import (
 	"github.com/go-faster/jx"
 )
 
+// Ref: #/components/schemas/AlgorithmParameterSpec
+type AlgorithmParameterSpec struct{}
+
 // Ref: #/components/schemas/Architecture
 type Architecture string
 
@@ -163,6 +166,11 @@ type CancelJobsForbidden struct{}
 
 func (*CancelJobsForbidden) cancelJobsRes() {}
 
+// CancelJobsNotFound is response for CancelJobs operation.
+type CancelJobsNotFound struct{}
+
+func (*CancelJobsNotFound) cancelJobsRes() {}
+
 // CancelJobsOK is response for CancelJobs operation.
 type CancelJobsOK struct{}
 
@@ -182,6 +190,7 @@ const (
 	CloudProviderNGC        CloudProvider = "NGC"
 	CloudProviderAZURE      CloudProvider = "AZURE"
 	CloudProviderRC         CloudProvider = "RC"
+	CloudProviderCOREWEAVE  CloudProvider = "COREWEAVE"
 	CloudProviderUNASSIGNED CloudProvider = "UNASSIGNED"
 )
 
@@ -193,6 +202,7 @@ func (CloudProvider) AllValues() []CloudProvider {
 		CloudProviderNGC,
 		CloudProviderAZURE,
 		CloudProviderRC,
+		CloudProviderCOREWEAVE,
 		CloudProviderUNASSIGNED,
 	}
 }
@@ -209,6 +219,8 @@ func (s CloudProvider) MarshalText() ([]byte, error) {
 	case CloudProviderAZURE:
 		return []byte(s), nil
 	case CloudProviderRC:
+		return []byte(s), nil
+	case CloudProviderCOREWEAVE:
 		return []byte(s), nil
 	case CloudProviderUNASSIGNED:
 		return []byte(s), nil
@@ -234,6 +246,9 @@ func (s *CloudProvider) UnmarshalText(data []byte) error {
 		return nil
 	case CloudProviderRC:
 		*s = CloudProviderRC
+		return nil
+	case CloudProviderCOREWEAVE:
+		*s = CloudProviderCOREWEAVE
 		return nil
 	case CloudProviderUNASSIGNED:
 		*s = CloudProviderUNASSIGNED
@@ -327,8 +342,11 @@ func (s *EnvPair) SetValue(val string) {
 
 // Ref: #/components/schemas/ExperimentalFields
 type ExperimentalFields struct {
-	CloudFileSystems     OptBool `json:"cloudFileSystems"`
+	CloudFileSystems OptBool `json:"cloudFileSystems"`
+	// Allows the job to use swap space equal to the amount of memory assigned. For example, a job with
+	// 128 MB of memory would also be allowed to use 128 MB of swap memory (disk).
 	KubernetesSwap       OptBool `json:"kubernetesSwap"`
+	PrivilegedMode       OptBool `json:"privilegedMode"`
 	RescaleFilesRDFAgent OptBool `json:"rescaleFilesRDFAgent"`
 }
 
@@ -340,6 +358,11 @@ func (s *ExperimentalFields) GetCloudFileSystems() OptBool {
 // GetKubernetesSwap returns the value of KubernetesSwap.
 func (s *ExperimentalFields) GetKubernetesSwap() OptBool {
 	return s.KubernetesSwap
+}
+
+// GetPrivilegedMode returns the value of PrivilegedMode.
+func (s *ExperimentalFields) GetPrivilegedMode() OptBool {
+	return s.PrivilegedMode
 }
 
 // GetRescaleFilesRDFAgent returns the value of RescaleFilesRDFAgent.
@@ -355,6 +378,11 @@ func (s *ExperimentalFields) SetCloudFileSystems(val OptBool) {
 // SetKubernetesSwap sets the value of KubernetesSwap.
 func (s *ExperimentalFields) SetKubernetesSwap(val OptBool) {
 	s.KubernetesSwap = val
+}
+
+// SetPrivilegedMode sets the value of PrivilegedMode.
+func (s *ExperimentalFields) SetPrivilegedMode(val OptBool) {
+	s.PrivilegedMode = val
 }
 
 // SetRescaleFilesRDFAgent sets the value of RescaleFilesRDFAgent.
@@ -479,6 +507,47 @@ func (*GetLimitsUnauthorized) getLimitsRes() {}
 type GetLogsForbidden struct{}
 
 func (*GetLogsForbidden) getLogsRes() {}
+
+type GetLogsSort string
+
+const (
+	GetLogsSortAsc  GetLogsSort = "asc"
+	GetLogsSortDesc GetLogsSort = "desc"
+)
+
+// AllValues returns all GetLogsSort values.
+func (GetLogsSort) AllValues() []GetLogsSort {
+	return []GetLogsSort{
+		GetLogsSortAsc,
+		GetLogsSortDesc,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s GetLogsSort) MarshalText() ([]byte, error) {
+	switch s {
+	case GetLogsSortAsc:
+		return []byte(s), nil
+	case GetLogsSortDesc:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *GetLogsSort) UnmarshalText(data []byte) error {
+	switch GetLogsSort(data) {
+	case GetLogsSortAsc:
+		*s = GetLogsSortAsc
+		return nil
+	case GetLogsSortDesc:
+		*s = GetLogsSortDesc
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
 
 // GetLogsUnauthorized is response for GetLogs operation.
 type GetLogsUnauthorized struct{}
@@ -1013,6 +1082,7 @@ const (
 	HTCComputeEnvironmentRegionAZUREUSSOUTHCENTRAL HTCComputeEnvironmentRegion = "AZURE_US_SOUTHCENTRAL"
 	HTCComputeEnvironmentRegionAZUREEUNORTH        HTCComputeEnvironmentRegion = "AZURE_EU_NORTH"
 	HTCComputeEnvironmentRegionRCICELAND1          HTCComputeEnvironmentRegion = "RC_ICELAND_1"
+	HTCComputeEnvironmentRegionCOREWEAVEUSEAST4    HTCComputeEnvironmentRegion = "COREWEAVE_US_EAST_4"
 	HTCComputeEnvironmentRegionUNASSIGNED          HTCComputeEnvironmentRegion = "UNASSIGNED"
 )
 
@@ -1048,6 +1118,7 @@ func (HTCComputeEnvironmentRegion) AllValues() []HTCComputeEnvironmentRegion {
 		HTCComputeEnvironmentRegionAZUREUSSOUTHCENTRAL,
 		HTCComputeEnvironmentRegionAZUREEUNORTH,
 		HTCComputeEnvironmentRegionRCICELAND1,
+		HTCComputeEnvironmentRegionCOREWEAVEUSEAST4,
 		HTCComputeEnvironmentRegionUNASSIGNED,
 	}
 }
@@ -1112,6 +1183,8 @@ func (s HTCComputeEnvironmentRegion) MarshalText() ([]byte, error) {
 	case HTCComputeEnvironmentRegionAZUREEUNORTH:
 		return []byte(s), nil
 	case HTCComputeEnvironmentRegionRCICELAND1:
+		return []byte(s), nil
+	case HTCComputeEnvironmentRegionCOREWEAVEUSEAST4:
 		return []byte(s), nil
 	case HTCComputeEnvironmentRegionUNASSIGNED:
 		return []byte(s), nil
@@ -1209,6 +1282,9 @@ func (s *HTCComputeEnvironmentRegion) UnmarshalText(data []byte) error {
 		return nil
 	case HTCComputeEnvironmentRegionRCICELAND1:
 		*s = HTCComputeEnvironmentRegionRCICELAND1
+		return nil
+	case HTCComputeEnvironmentRegionCOREWEAVEUSEAST4:
+		*s = HTCComputeEnvironmentRegionCOREWEAVEUSEAST4
 		return nil
 	case HTCComputeEnvironmentRegionUNASSIGNED:
 		*s = HTCComputeEnvironmentRegionUNASSIGNED
@@ -1320,6 +1396,7 @@ type HTCJob struct {
 	JobExecutionEnvironment OptJobExecutionEnvironment `json:"jobExecutionEnvironment"`
 	JobUUID                 OptString                  `json:"jobUUID"`
 	MaxDiskGiB              OptInt32                   `json:"maxDiskGiB"`
+	MaxGpus                 OptInt32                   `json:"maxGpus"`
 	MaxMemory               OptInt32                   `json:"maxMemory"`
 	MaxSwap                 OptInt32                   `json:"maxSwap"`
 	MaxVCpus                OptInt32                   `json:"maxVCpus"`
@@ -1414,6 +1491,11 @@ func (s *HTCJob) GetJobUUID() OptString {
 // GetMaxDiskGiB returns the value of MaxDiskGiB.
 func (s *HTCJob) GetMaxDiskGiB() OptInt32 {
 	return s.MaxDiskGiB
+}
+
+// GetMaxGpus returns the value of MaxGpus.
+func (s *HTCJob) GetMaxGpus() OptInt32 {
+	return s.MaxGpus
 }
 
 // GetMaxMemory returns the value of MaxMemory.
@@ -1566,6 +1648,11 @@ func (s *HTCJob) SetMaxDiskGiB(val OptInt32) {
 	s.MaxDiskGiB = val
 }
 
+// SetMaxGpus sets the value of MaxGpus.
+func (s *HTCJob) SetMaxGpus(val OptInt32) {
+	s.MaxGpus = val
+}
+
 // SetMaxMemory sets the value of MaxMemory.
 func (s *HTCJob) SetMaxMemory(val OptInt32) {
 	s.MaxMemory = val
@@ -1640,24 +1727,28 @@ func (*HTCJob) getJobRes() {}
 
 // Ref: #/components/schemas/HTCJobDefinition
 type HTCJobDefinition struct {
-	Architecture       OptArchitecture `json:"architecture"`
-	Claims             []NameValuePair `json:"claims"`
-	Commands           []string        `json:"commands"`
-	Envs               []EnvPair       `json:"envs"`
-	SecretEnvs         []SecretEnvPair `json:"secretEnvs"`
-	ExecTimeoutSeconds OptInt32        `json:"execTimeoutSeconds"`
-	ImageName          string          `json:"imageName"`
+	Architecture OptArchitecture `json:"architecture"`
+	Claims       []NameValuePair `json:"claims"`
+	Commands     []string        `json:"commands"`
+	// Must not be reserved environment variable:AWS_BATCH_CE_NAME |AWS_BATCH_JOB_ARRAY_INDEX
+	// |AWS_BATCH_JOB_ATTEMPT |AWS_BATCH_JOB_ID |AWS_BATCH_JOB_MAIN_NODE_INDEX
+	// |AWS_BATCH_JOB_MAIN_NODE_PRIVATE_IPV4_ADDRESS |AWS_BATCH_JOB_NODE_INDEX |AWS_BATCH_JOB_NUM_NODES
+	// |AWS_BATCH_JQ_NAME |RESCALE_PROJECT_ID |RESCALE_TASK_ID |RESCALE_JOB_ID |RESCALE_HTC_REGION
+	// |RESCALE_HTC_TASK_ID |RESCALE_HTC_PROJECT_ID |RESCALE_HTC_BEARER_TOKEN |PROJECT_SHARED_FOLDER
+	// |TASK_SHARED_FOLDER |AWS_SESSION_TOKEN |AWS_ACCESS_KEY_ID |AWS_SECRET_ACCESS_KEY.
+	Envs               []HTCJobDefinitionEnvsItem `json:"envs"`
+	ExecTimeoutSeconds OptInt32                   `json:"execTimeoutSeconds"`
+	ImageName          string                     `json:"imageName"`
 	// MaxDiskGiB is supported on GCP only.
 	MaxDiskGiB OptInt32 `json:"maxDiskGiB"`
 	MaxMemory  OptInt32 `json:"maxMemory"`
-	// On AWS, maxSwap allows swap memory to be used, up to the limit. On other providers, swap is not
-	// available, but maxSwap is added to the maxMemory to provide the same amount of available space.
-	// The default value is 2000 MB.
-	MaxSwap    OptInt32                `json:"maxSwap"`
-	MaxVCpus   OptInt32                `json:"maxVCpus"`
-	Priority   OptJobPriority          `json:"priority"`
-	Tags       OptHTCJobDefinitionTags `json:"tags"`
-	WorkingDir OptNilString            `json:"workingDir"`
+	// Deprecated. This field has no effect and may be removed at any time.
+	MaxSwap  OptInt32 `json:"maxSwap"`
+	MaxVCpus OptInt32 `json:"maxVCpus"`
+	// ON_DEMAND_ECONOMY uses spot instances and may be preempted.
+	Priority   OptHTCJobDefinitionPriority `json:"priority"`
+	Tags       OptHTCJobDefinitionTags     `json:"tags"`
+	WorkingDir OptNilString                `json:"workingDir"`
 }
 
 // GetArchitecture returns the value of Architecture.
@@ -1676,13 +1767,8 @@ func (s *HTCJobDefinition) GetCommands() []string {
 }
 
 // GetEnvs returns the value of Envs.
-func (s *HTCJobDefinition) GetEnvs() []EnvPair {
+func (s *HTCJobDefinition) GetEnvs() []HTCJobDefinitionEnvsItem {
 	return s.Envs
-}
-
-// GetSecretEnvs returns the value of SecretEnvs.
-func (s *HTCJobDefinition) GetSecretEnvs() []SecretEnvPair {
-	return s.SecretEnvs
 }
 
 // GetExecTimeoutSeconds returns the value of ExecTimeoutSeconds.
@@ -1716,7 +1802,7 @@ func (s *HTCJobDefinition) GetMaxVCpus() OptInt32 {
 }
 
 // GetPriority returns the value of Priority.
-func (s *HTCJobDefinition) GetPriority() OptJobPriority {
+func (s *HTCJobDefinition) GetPriority() OptHTCJobDefinitionPriority {
 	return s.Priority
 }
 
@@ -1746,13 +1832,8 @@ func (s *HTCJobDefinition) SetCommands(val []string) {
 }
 
 // SetEnvs sets the value of Envs.
-func (s *HTCJobDefinition) SetEnvs(val []EnvPair) {
+func (s *HTCJobDefinition) SetEnvs(val []HTCJobDefinitionEnvsItem) {
 	s.Envs = val
-}
-
-// SetSecretEnvs sets the value of SecretEnvs.
-func (s *HTCJobDefinition) SetSecretEnvs(val []SecretEnvPair) {
-	s.SecretEnvs = val
 }
 
 // SetExecTimeoutSeconds sets the value of ExecTimeoutSeconds.
@@ -1786,7 +1867,7 @@ func (s *HTCJobDefinition) SetMaxVCpus(val OptInt32) {
 }
 
 // SetPriority sets the value of Priority.
-func (s *HTCJobDefinition) SetPriority(val OptJobPriority) {
+func (s *HTCJobDefinition) SetPriority(val OptHTCJobDefinitionPriority) {
 	s.Priority = val
 }
 
@@ -1798,6 +1879,72 @@ func (s *HTCJobDefinition) SetTags(val OptHTCJobDefinitionTags) {
 // SetWorkingDir sets the value of WorkingDir.
 func (s *HTCJobDefinition) SetWorkingDir(val OptNilString) {
 	s.WorkingDir = val
+}
+
+type HTCJobDefinitionEnvsItem struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// GetName returns the value of Name.
+func (s *HTCJobDefinitionEnvsItem) GetName() string {
+	return s.Name
+}
+
+// GetValue returns the value of Value.
+func (s *HTCJobDefinitionEnvsItem) GetValue() string {
+	return s.Value
+}
+
+// SetName sets the value of Name.
+func (s *HTCJobDefinitionEnvsItem) SetName(val string) {
+	s.Name = val
+}
+
+// SetValue sets the value of Value.
+func (s *HTCJobDefinitionEnvsItem) SetValue(val string) {
+	s.Value = val
+}
+
+type HTCJobDefinitionPriority string
+
+const (
+	HTCJobDefinitionPriorityONDEMANDPRIORITY HTCJobDefinitionPriority = "ON_DEMAND_PRIORITY"
+	HTCJobDefinitionPriorityONDEMANDECONOMY  HTCJobDefinitionPriority = "ON_DEMAND_ECONOMY"
+)
+
+// AllValues returns all HTCJobDefinitionPriority values.
+func (HTCJobDefinitionPriority) AllValues() []HTCJobDefinitionPriority {
+	return []HTCJobDefinitionPriority{
+		HTCJobDefinitionPriorityONDEMANDPRIORITY,
+		HTCJobDefinitionPriorityONDEMANDECONOMY,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s HTCJobDefinitionPriority) MarshalText() ([]byte, error) {
+	switch s {
+	case HTCJobDefinitionPriorityONDEMANDPRIORITY:
+		return []byte(s), nil
+	case HTCJobDefinitionPriorityONDEMANDECONOMY:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *HTCJobDefinitionPriority) UnmarshalText(data []byte) error {
+	switch HTCJobDefinitionPriority(data) {
+	case HTCJobDefinitionPriorityONDEMANDPRIORITY:
+		*s = HTCJobDefinitionPriorityONDEMANDPRIORITY
+		return nil
+	case HTCJobDefinitionPriorityONDEMANDECONOMY:
+		*s = HTCJobDefinitionPriorityONDEMANDECONOMY
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
 }
 
 type HTCJobDefinitionTags map[string]string
@@ -2740,6 +2887,7 @@ const (
 	HTCRegionAdminSettingsRegionAZUREUSSOUTHCENTRAL HTCRegionAdminSettingsRegion = "AZURE_US_SOUTHCENTRAL"
 	HTCRegionAdminSettingsRegionAZUREEUNORTH        HTCRegionAdminSettingsRegion = "AZURE_EU_NORTH"
 	HTCRegionAdminSettingsRegionRCICELAND1          HTCRegionAdminSettingsRegion = "RC_ICELAND_1"
+	HTCRegionAdminSettingsRegionCOREWEAVEUSEAST4    HTCRegionAdminSettingsRegion = "COREWEAVE_US_EAST_4"
 	HTCRegionAdminSettingsRegionUNASSIGNED          HTCRegionAdminSettingsRegion = "UNASSIGNED"
 )
 
@@ -2775,6 +2923,7 @@ func (HTCRegionAdminSettingsRegion) AllValues() []HTCRegionAdminSettingsRegion {
 		HTCRegionAdminSettingsRegionAZUREUSSOUTHCENTRAL,
 		HTCRegionAdminSettingsRegionAZUREEUNORTH,
 		HTCRegionAdminSettingsRegionRCICELAND1,
+		HTCRegionAdminSettingsRegionCOREWEAVEUSEAST4,
 		HTCRegionAdminSettingsRegionUNASSIGNED,
 	}
 }
@@ -2839,6 +2988,8 @@ func (s HTCRegionAdminSettingsRegion) MarshalText() ([]byte, error) {
 	case HTCRegionAdminSettingsRegionAZUREEUNORTH:
 		return []byte(s), nil
 	case HTCRegionAdminSettingsRegionRCICELAND1:
+		return []byte(s), nil
+	case HTCRegionAdminSettingsRegionCOREWEAVEUSEAST4:
 		return []byte(s), nil
 	case HTCRegionAdminSettingsRegionUNASSIGNED:
 		return []byte(s), nil
@@ -2936,6 +3087,9 @@ func (s *HTCRegionAdminSettingsRegion) UnmarshalText(data []byte) error {
 		return nil
 	case HTCRegionAdminSettingsRegionRCICELAND1:
 		*s = HTCRegionAdminSettingsRegionRCICELAND1
+		return nil
+	case HTCRegionAdminSettingsRegionCOREWEAVEUSEAST4:
+		*s = HTCRegionAdminSettingsRegionCOREWEAVEUSEAST4
 		return nil
 	case HTCRegionAdminSettingsRegionUNASSIGNED:
 		*s = HTCRegionAdminSettingsRegionUNASSIGNED
@@ -4227,48 +4381,6 @@ func (s *JobExecutionEnvironment) SetInstanceType(val OptString) {
 	s.InstanceType = val
 }
 
-// Ref: #/components/schemas/JobPriority
-type JobPriority string
-
-const (
-	JobPriorityONDEMANDPRIORITY JobPriority = "ON_DEMAND_PRIORITY"
-	JobPriorityONDEMANDECONOMY  JobPriority = "ON_DEMAND_ECONOMY"
-)
-
-// AllValues returns all JobPriority values.
-func (JobPriority) AllValues() []JobPriority {
-	return []JobPriority{
-		JobPriorityONDEMANDPRIORITY,
-		JobPriorityONDEMANDECONOMY,
-	}
-}
-
-// MarshalText implements encoding.TextMarshaler.
-func (s JobPriority) MarshalText() ([]byte, error) {
-	switch s {
-	case JobPriorityONDEMANDPRIORITY:
-		return []byte(s), nil
-	case JobPriorityONDEMANDECONOMY:
-		return []byte(s), nil
-	default:
-		return nil, errors.Errorf("invalid value: %q", s)
-	}
-}
-
-// UnmarshalText implements encoding.TextUnmarshaler.
-func (s *JobPriority) UnmarshalText(data []byte) error {
-	switch JobPriority(data) {
-	case JobPriorityONDEMANDPRIORITY:
-		*s = JobPriorityONDEMANDPRIORITY
-		return nil
-	case JobPriorityONDEMANDECONOMY:
-		*s = JobPriorityONDEMANDECONOMY
-		return nil
-	default:
-		return errors.Errorf("invalid value: %q", data)
-	}
-}
-
 // Ref: #/components/schemas/JsonWebKey
 type JsonWebKey struct {
 	Algorithm       OptString                    `json:"algorithm"`
@@ -4578,14 +4690,53 @@ func (s *OAuth2ErrorResponse) SetErrorDescription(val OptString) {
 	s.ErrorDescription = val
 }
 
-func (*OAuth2ErrorResponse) authTokenWhoamiGetRes()           {}
-func (*OAuth2ErrorResponse) getTokenRes()                     {}
-func (*OAuth2ErrorResponse) htcGcpClustersWorkspaceIdGetRes() {}
-func (*OAuth2ErrorResponse) htcRegionsGetRes()                {}
-func (*OAuth2ErrorResponse) htcRegionsRegionGetRes()          {}
-func (*OAuth2ErrorResponse) oAuth2TokenPostRes()              {}
-func (*OAuth2ErrorResponse) wellKnownJwksJSONGetRes()         {}
-func (*OAuth2ErrorResponse) whoAmIRes()                       {}
+func (*OAuth2ErrorResponse) authTokenWhoamiGetRes()                                       {}
+func (*OAuth2ErrorResponse) createRepoRes()                                               {}
+func (*OAuth2ErrorResponse) createTaskRes()                                               {}
+func (*OAuth2ErrorResponse) getDimensionsRes()                                            {}
+func (*OAuth2ErrorResponse) getImagesRes()                                                {}
+func (*OAuth2ErrorResponse) getLimitsRes()                                                {}
+func (*OAuth2ErrorResponse) getProjectRes()                                               {}
+func (*OAuth2ErrorResponse) getRegistryTokenRes()                                         {}
+func (*OAuth2ErrorResponse) getTasksRes()                                                 {}
+func (*OAuth2ErrorResponse) getTokenRes()                                                 {}
+func (*OAuth2ErrorResponse) htcGcpClustersWorkspaceIdGetRes()                             {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdDimensionsPutRes()                        {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdLimitsDeleteRes()                         {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdLimitsIDDeleteRes()                       {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdLimitsIDGetRes()                          {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdLimitsIDPatchRes()                        {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdLimitsPostRes()                           {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdPatchRes()                                {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdStoragePresignedURLGetRes()               {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdStorageTokenGetRes()                      {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdStorageTokenRegionGetRes()                {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdStorageTokensGetRes()                     {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTaskRetentionPolicyDeleteRes()            {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTaskRetentionPolicyGetRes()               {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTaskRetentionPolicyPutRes()               {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdDeleteRes()                    {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdGetRes()                       {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdGroupSummaryStatisticsGetRes() {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdGroupsGetRes()                 {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdJobsJobIdEventsGetRes()        {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdPatchRes()                     {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdStoragePresignedURLGetRes()    {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdStorageRegionalStorageGetRes() {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdStorageTokenGetRes()           {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdStorageTokenRegionGetRes()     {}
+func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdStorageTokensGetRes()          {}
+func (*OAuth2ErrorResponse) htcRegionsGetRes()                                            {}
+func (*OAuth2ErrorResponse) htcRegionsRegionGetRes()                                      {}
+func (*OAuth2ErrorResponse) htcStorageRegionRegionGetRes()                                {}
+func (*OAuth2ErrorResponse) htcWorkspacesWorkspaceIdDimensionsGetRes()                    {}
+func (*OAuth2ErrorResponse) htcWorkspacesWorkspaceIdLimitsGetRes()                        {}
+func (*OAuth2ErrorResponse) htcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes()           {}
+func (*OAuth2ErrorResponse) htcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes()           {}
+func (*OAuth2ErrorResponse) oAuth2TokenPostRes()                                          {}
+func (*OAuth2ErrorResponse) submitJobsRes()                                               {}
+func (*OAuth2ErrorResponse) wellKnownJwksJSONGetRes()                                     {}
+func (*OAuth2ErrorResponse) whoAmIRes()                                                   {}
 
 // Ref: #/components/schemas/OAuth2Token
 type OAuth2Token struct {
@@ -5086,6 +5237,52 @@ func (o OptFloat64) Or(d float64) float64 {
 	return d
 }
 
+// NewOptGetLogsSort returns new OptGetLogsSort with value set to v.
+func NewOptGetLogsSort(v GetLogsSort) OptGetLogsSort {
+	return OptGetLogsSort{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptGetLogsSort is optional GetLogsSort.
+type OptGetLogsSort struct {
+	Value GetLogsSort
+	Set   bool
+}
+
+// IsSet returns true if OptGetLogsSort was set.
+func (o OptGetLogsSort) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptGetLogsSort) Reset() {
+	var v GetLogsSort
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptGetLogsSort) SetTo(v GetLogsSort) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptGetLogsSort) Get() (v GetLogsSort, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptGetLogsSort) Or(d GetLogsSort) GetLogsSort {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 // NewOptHTCComputeEnvironmentComputeScalingPolicy returns new OptHTCComputeEnvironmentComputeScalingPolicy with value set to v.
 func NewOptHTCComputeEnvironmentComputeScalingPolicy(v HTCComputeEnvironmentComputeScalingPolicy) OptHTCComputeEnvironmentComputeScalingPolicy {
 	return OptHTCComputeEnvironmentComputeScalingPolicy{
@@ -5310,6 +5507,52 @@ func (o OptHTCComputeEnvironmentRegion) Get() (v HTCComputeEnvironmentRegion, ok
 
 // Or returns value if set, or given parameter if does not.
 func (o OptHTCComputeEnvironmentRegion) Or(d HTCComputeEnvironmentRegion) HTCComputeEnvironmentRegion {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptHTCJobDefinitionPriority returns new OptHTCJobDefinitionPriority with value set to v.
+func NewOptHTCJobDefinitionPriority(v HTCJobDefinitionPriority) OptHTCJobDefinitionPriority {
+	return OptHTCJobDefinitionPriority{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptHTCJobDefinitionPriority is optional HTCJobDefinitionPriority.
+type OptHTCJobDefinitionPriority struct {
+	Value HTCJobDefinitionPriority
+	Set   bool
+}
+
+// IsSet returns true if OptHTCJobDefinitionPriority was set.
+func (o OptHTCJobDefinitionPriority) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptHTCJobDefinitionPriority) Reset() {
+	var v HTCJobDefinitionPriority
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptHTCJobDefinitionPriority) SetTo(v HTCJobDefinitionPriority) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptHTCJobDefinitionPriority) Get() (v HTCJobDefinitionPriority, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptHTCJobDefinitionPriority) Or(d HTCJobDefinitionPriority) HTCJobDefinitionPriority {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -6092,52 +6335,6 @@ func (o OptJobExecutionEnvironment) Get() (v JobExecutionEnvironment, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptJobExecutionEnvironment) Or(d JobExecutionEnvironment) JobExecutionEnvironment {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptJobPriority returns new OptJobPriority with value set to v.
-func NewOptJobPriority(v JobPriority) OptJobPriority {
-	return OptJobPriority{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptJobPriority is optional JobPriority.
-type OptJobPriority struct {
-	Value JobPriority
-	Set   bool
-}
-
-// IsSet returns true if OptJobPriority was set.
-func (o OptJobPriority) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptJobPriority) Reset() {
-	var v JobPriority
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptJobPriority) SetTo(v JobPriority) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptJobPriority) Get() (v JobPriority, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptJobPriority) Or(d JobPriority) JobPriority {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -7353,9 +7550,10 @@ func (s *PresignedPutUrlResponseURL) SetSerializedHashCode(val OptInt32) {
 
 // Ref: #/components/schemas/PublicKey
 type PublicKey struct {
-	Algorithm OptString `json:"algorithm"`
-	Encoded   OptString `json:"encoded"`
-	Format    OptString `json:"format"`
+	Algorithm OptString               `json:"algorithm"`
+	Encoded   OptString               `json:"encoded"`
+	Format    OptString               `json:"format"`
+	Params    *AlgorithmParameterSpec `json:"params"`
 }
 
 // GetAlgorithm returns the value of Algorithm.
@@ -7373,6 +7571,11 @@ func (s *PublicKey) GetFormat() OptString {
 	return s.Format
 }
 
+// GetParams returns the value of Params.
+func (s *PublicKey) GetParams() *AlgorithmParameterSpec {
+	return s.Params
+}
+
 // SetAlgorithm sets the value of Algorithm.
 func (s *PublicKey) SetAlgorithm(val OptString) {
 	s.Algorithm = val
@@ -7386,6 +7589,11 @@ func (s *PublicKey) SetEncoded(val OptString) {
 // SetFormat sets the value of Format.
 func (s *PublicKey) SetFormat(val OptString) {
 	s.Format = val
+}
+
+// SetParams sets the value of Params.
+func (s *PublicKey) SetParams(val *AlgorithmParameterSpec) {
+	s.Params = val
 }
 
 // Ref: #/components/schemas/RegionStorageOption
@@ -7675,6 +7883,7 @@ const (
 	RescaleRegionAZUREUSSOUTHCENTRAL RescaleRegion = "AZURE_US_SOUTHCENTRAL"
 	RescaleRegionAZUREEUNORTH        RescaleRegion = "AZURE_EU_NORTH"
 	RescaleRegionRCICELAND1          RescaleRegion = "RC_ICELAND_1"
+	RescaleRegionCOREWEAVEUSEAST4    RescaleRegion = "COREWEAVE_US_EAST_4"
 	RescaleRegionUNASSIGNED          RescaleRegion = "UNASSIGNED"
 )
 
@@ -7710,6 +7919,7 @@ func (RescaleRegion) AllValues() []RescaleRegion {
 		RescaleRegionAZUREUSSOUTHCENTRAL,
 		RescaleRegionAZUREEUNORTH,
 		RescaleRegionRCICELAND1,
+		RescaleRegionCOREWEAVEUSEAST4,
 		RescaleRegionUNASSIGNED,
 	}
 }
@@ -7774,6 +7984,8 @@ func (s RescaleRegion) MarshalText() ([]byte, error) {
 	case RescaleRegionAZUREEUNORTH:
 		return []byte(s), nil
 	case RescaleRegionRCICELAND1:
+		return []byte(s), nil
+	case RescaleRegionCOREWEAVEUSEAST4:
 		return []byte(s), nil
 	case RescaleRegionUNASSIGNED:
 		return []byte(s), nil
@@ -7871,6 +8083,9 @@ func (s *RescaleRegion) UnmarshalText(data []byte) error {
 		return nil
 	case RescaleRegionRCICELAND1:
 		*s = RescaleRegionRCICELAND1
+		return nil
+	case RescaleRegionCOREWEAVEUSEAST4:
+		*s = RescaleRegionCOREWEAVEUSEAST4
 		return nil
 	case RescaleRegionUNASSIGNED:
 		*s = RescaleRegionUNASSIGNED
@@ -8025,32 +8240,6 @@ func (s *RescaleUser) SetWorkspace(val OptWorkspace) {
 // SetWorkspaceAdmin sets the value of WorkspaceAdmin.
 func (s *RescaleUser) SetWorkspaceAdmin(val OptBool) {
 	s.WorkspaceAdmin = val
-}
-
-// Ref: #/components/schemas/SecretEnvPair
-type SecretEnvPair struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
-}
-
-// GetName returns the value of Name.
-func (s *SecretEnvPair) GetName() string {
-	return s.Name
-}
-
-// GetValue returns the value of Value.
-func (s *SecretEnvPair) GetValue() string {
-	return s.Value
-}
-
-// SetName sets the value of Name.
-func (s *SecretEnvPair) SetName(val string) {
-	s.Name = val
-}
-
-// SetValue sets the value of Value.
-func (s *SecretEnvPair) SetValue(val string) {
-	s.Value = val
 }
 
 type SecurityScheme struct {

--- a/v2/api/_oas/oas_schemas_gen.go
+++ b/v2/api/_oas/oas_schemas_gen.go
@@ -11,9 +11,6 @@ import (
 	"github.com/go-faster/jx"
 )
 
-// Ref: #/components/schemas/AlgorithmParameterSpec
-type AlgorithmParameterSpec struct{}
-
 // Ref: #/components/schemas/Architecture
 type Architecture string
 
@@ -7550,10 +7547,9 @@ func (s *PresignedPutUrlResponseURL) SetSerializedHashCode(val OptInt32) {
 
 // Ref: #/components/schemas/PublicKey
 type PublicKey struct {
-	Algorithm OptString               `json:"algorithm"`
-	Encoded   OptString               `json:"encoded"`
-	Format    OptString               `json:"format"`
-	Params    *AlgorithmParameterSpec `json:"params"`
+	Algorithm OptString `json:"algorithm"`
+	Encoded   OptString `json:"encoded"`
+	Format    OptString `json:"format"`
 }
 
 // GetAlgorithm returns the value of Algorithm.
@@ -7571,11 +7567,6 @@ func (s *PublicKey) GetFormat() OptString {
 	return s.Format
 }
 
-// GetParams returns the value of Params.
-func (s *PublicKey) GetParams() *AlgorithmParameterSpec {
-	return s.Params
-}
-
 // SetAlgorithm sets the value of Algorithm.
 func (s *PublicKey) SetAlgorithm(val OptString) {
 	s.Algorithm = val
@@ -7589,11 +7580,6 @@ func (s *PublicKey) SetEncoded(val OptString) {
 // SetFormat sets the value of Format.
 func (s *PublicKey) SetFormat(val OptString) {
 	s.Format = val
-}
-
-// SetParams sets the value of Params.
-func (s *PublicKey) SetParams(val *AlgorithmParameterSpec) {
-	s.Params = val
 }
 
 // Ref: #/components/schemas/RegionStorageOption

--- a/v2/api/_oas/oas_server_gen.go
+++ b/v2/api/_oas/oas_server_gen.go
@@ -347,7 +347,7 @@ type AuthHandler interface {
 	// This endpoint will get a JWT token given an API key.
 	//
 	// GET /auth/token
-	GetToken(ctx context.Context) (GetTokenRes, error)
+	GetToken(ctx context.Context, params GetTokenParams) (GetTokenRes, error)
 	// WhoAmI implements whoAmI operation.
 	//
 	// This endpoint will get Rescale user information given a Rescale API key.

--- a/v2/api/_oas/oas_unimplemented_gen.go
+++ b/v2/api/_oas/oas_unimplemented_gen.go
@@ -197,7 +197,7 @@ func (UnimplementedHandler) GetTasks(ctx context.Context, params GetTasksParams)
 // This endpoint will get a JWT token given an API key.
 //
 // GET /auth/token
-func (UnimplementedHandler) GetToken(ctx context.Context) (r GetTokenRes, _ error) {
+func (UnimplementedHandler) GetToken(ctx context.Context, params GetTokenParams) (r GetTokenRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 

--- a/v2/api/_oas/oas_validators_gen.go
+++ b/v2/api/_oas/oas_validators_gen.go
@@ -50,6 +50,8 @@ func (s CloudProvider) Validate() error {
 		return nil
 	case "RC":
 		return nil
+	case "COREWEAVE":
+		return nil
 	case "UNASSIGNED":
 		return nil
 	default:
@@ -116,6 +118,17 @@ func (s *EnvPair) Validate() error {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s GetLogsSort) Validate() error {
+	switch s {
+	case "asc":
+		return nil
+	case "desc":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s *HTCCluster) Validate() error {
@@ -433,6 +446,8 @@ func (s HTCComputeEnvironmentRegion) Validate() error {
 	case "AZURE_EU_NORTH":
 		return nil
 	case "RC_ICELAND_1":
+		return nil
+	case "COREWEAVE_US_EAST_4":
 		return nil
 	case "UNASSIGNED":
 		return nil
@@ -879,6 +894,48 @@ func (s *HTCJobDefinition) Validate() error {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s *HTCJobDefinitionEnvsItem) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := (validate.String{
+			MinLength:    0,
+			MinLengthSet: false,
+			MaxLength:    0,
+			MaxLengthSet: false,
+			Email:        false,
+			Hostname:     false,
+			Regex:        regexMap["^(?!.*AWS_BATCH_|RESCALE_PROJECT_ID|RESCALE_TASK_ID|RESCALE_JOB_ID|PROJECT_SHARED_FOLDER|TASK_SHARED_FOLDER|AWS_SESSION_TOKEN|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|RDF_).*"],
+		}).Validate(string(s.Name)); err != nil {
+			return errors.Wrap(err, "string")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "name",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s HTCJobDefinitionPriority) Validate() error {
+	switch s {
+	case "ON_DEMAND_PRIORITY":
+		return nil
+	case "ON_DEMAND_ECONOMY":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s HTCJobFailureCode) Validate() error {
@@ -1524,6 +1581,8 @@ func (s HTCRegionAdminSettingsRegion) Validate() error {
 		return nil
 	case "RC_ICELAND_1":
 		return nil
+	case "COREWEAVE_US_EAST_4":
+		return nil
 	case "UNASSIGNED":
 		return nil
 	default:
@@ -1968,17 +2027,6 @@ func (s *JobExecutionEnvironment) Validate() error {
 	return nil
 }
 
-func (s JobPriority) Validate() error {
-	switch s {
-	case "ON_DEMAND_PRIORITY":
-		return nil
-	case "ON_DEMAND_ECONOMY":
-		return nil
-	default:
-		return errors.Errorf("invalid value: %v", s)
-	}
-}
-
 func (s ModifierRole) Validate() error {
 	switch s {
 	case "WORKSPACE_ADMIN":
@@ -2255,6 +2303,8 @@ func (s RescaleRegion) Validate() error {
 	case "AZURE_EU_NORTH":
 		return nil
 	case "RC_ICELAND_1":
+		return nil
+	case "COREWEAVE_US_EAST_4":
 		return nil
 	case "UNASSIGNED":
 		return nil

--- a/v2/api/swagger-patched.json
+++ b/v2/api/swagger-patched.json
@@ -1,9 +1,6 @@
 {
    "components": {
       "schemas": {
-         "AlgorithmParameterSpec": {
-            "type": "object"
-         },
          "Architecture": {
             "enum": [
                "AARCH64",
@@ -1571,9 +1568,6 @@
                },
                "format": {
                   "type": "string"
-               },
-               "params": {
-                  "$ref": "#/components/schemas/AlgorithmParameterSpec"
                }
             },
             "type": "object"
@@ -5527,7 +5521,7 @@
    },
    "servers": [
       {
-         "url": "http://localhost:8080/api/v1"
+         "url": "https://htc.rescale.com/api/v1"
       }
    ]
 }

--- a/v2/api/swagger-patched.json
+++ b/v2/api/swagger-patched.json
@@ -2738,8 +2738,7 @@
                            "$ref": "#/components/schemas/OAuth2ErrorResponse"
                         }
                      }
-                  },
-                  "description": "Not Found"
+                  }
                }
             },
             "security": [

--- a/v2/api/swagger-patched.json
+++ b/v2/api/swagger-patched.json
@@ -1,6 +1,9 @@
 {
    "components": {
       "schemas": {
+         "AlgorithmParameterSpec": {
+            "type": "object"
+         },
          "Architecture": {
             "enum": [
                "AARCH64",
@@ -41,6 +44,7 @@
                "NGC",
                "AZURE",
                "RC",
+               "COREWEAVE",
                "UNASSIGNED"
             ],
             "type": "string"
@@ -104,29 +108,16 @@
             ],
             "type": "object"
          },
-         "SecretEnvPair": {
-            "properties": {
-               "name": {
-                  "example": "FOO",
-                  "type": "string"
-               },
-               "value": {
-                  "example": "bar",
-                  "type": "string"
-               }
-            },
-            "required": [
-               "name",
-               "value"
-            ],
-            "type": "object"
-         },
          "ExperimentalFields": {
             "properties": {
                "cloudFileSystems": {
                   "type": "boolean"
                },
                "kubernetesSwap": {
+                  "description": "Allows the job to use swap space equal to the amount of memory assigned. For example, a job with 128 MB of memory would also be allowed to use 128 MB of swap memory (disk)",
+                  "type": "boolean"
+               },
+               "privilegedMode": {
                   "type": "boolean"
                },
                "rescaleFilesRDFAgent": {
@@ -352,10 +343,14 @@
                   "$ref": "#/components/schemas/JobExecutionEnvironment"
                },
                "jobUUID": {
-                  "example": "155f18d4",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "type": "string"
                },
                "maxDiskGiB": {
+                  "format": "int32",
+                  "type": "integer"
+               },
+               "maxGpus": {
                   "format": "int32",
                   "type": "integer"
                },
@@ -376,7 +371,7 @@
                   "type": "integer"
                },
                "projectId": {
-                  "example": "project-12345",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "type": "string"
                },
                "providerJobId": {
@@ -404,7 +399,7 @@
                   "type": "array"
                },
                "taskId": {
-                  "example": "task-12345",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "type": "string"
                },
                "updatedAt": {
@@ -439,14 +434,24 @@
                   "type": "array"
                },
                "envs": {
+                  "description": "Must not be reserved environment variable:AWS_BATCH_CE_NAME |AWS_BATCH_JOB_ARRAY_INDEX |AWS_BATCH_JOB_ATTEMPT |AWS_BATCH_JOB_ID |AWS_BATCH_JOB_MAIN_NODE_INDEX |AWS_BATCH_JOB_MAIN_NODE_PRIVATE_IPV4_ADDRESS |AWS_BATCH_JOB_NODE_INDEX |AWS_BATCH_JOB_NUM_NODES |AWS_BATCH_JQ_NAME |RESCALE_PROJECT_ID |RESCALE_TASK_ID |RESCALE_JOB_ID |RESCALE_HTC_REGION |RESCALE_HTC_TASK_ID |RESCALE_HTC_PROJECT_ID |RESCALE_HTC_BEARER_TOKEN |PROJECT_SHARED_FOLDER |TASK_SHARED_FOLDER |AWS_SESSION_TOKEN |AWS_ACCESS_KEY_ID |AWS_SECRET_ACCESS_KEY",
                   "items": {
-                     "$ref": "#/components/schemas/EnvPair"
-                  },
-                  "type": "array"
-               },
-               "secretEnvs": {
-                  "items": {
-                     "$ref": "#/components/schemas/SecretEnvPair"
+                     "properties": {
+                        "name": {
+                           "example": "FOO",
+                           "pattern": "^(?!.*AWS_BATCH_|RESCALE_PROJECT_ID|RESCALE_TASK_ID|RESCALE_JOB_ID|PROJECT_SHARED_FOLDER|TASK_SHARED_FOLDER|AWS_SESSION_TOKEN|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|RDF_).*",
+                           "type": "string"
+                        },
+                        "value": {
+                           "example": "bar",
+                           "type": "string"
+                        }
+                     },
+                     "required": [
+                        "name",
+                        "value"
+                     ],
+                     "type": "object"
                   },
                   "type": "array"
                },
@@ -479,7 +484,7 @@
                   "type": "integer"
                },
                "maxSwap": {
-                  "description": "On AWS, maxSwap allows swap memory to be used, up to the limit. On other providers, swap is not available, but maxSwap is added to the maxMemory to provide the same amount of available space. The default value is 2000 MB",
+                  "description": "Deprecated. This field has no effect and may be removed at any time.",
                   "format": "int32",
                   "minimum": 0,
                   "type": "integer"
@@ -492,7 +497,13 @@
                   "type": "integer"
                },
                "priority": {
-                  "$ref": "#/components/schemas/JobPriority"
+                  "allOf": [
+                     {
+                        "$ref": "#/components/schemas/JobPriority"
+                     }
+                  ],
+                  "description": "ON_DEMAND_ECONOMY uses spot instances and may be preempted.",
+                  "type": "string"
                },
                "tags": {
                   "additionalProperties": {
@@ -591,12 +602,12 @@
                   "type": "string"
                },
                "parentJobId": {
-                  "example": "job-12345",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "readOnly": true,
                   "type": "string"
                },
                "projectId": {
-                  "example": "project-12345",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "readOnly": true,
                   "type": "string"
                },
@@ -631,7 +642,7 @@
                   "type": "array"
                },
                "taskId": {
-                  "example": "task-12345",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "readOnly": true,
                   "type": "string"
                },
@@ -765,7 +776,7 @@
                   "type": "string"
                },
                "projectId": {
-                  "example": "project-12345",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "readOnly": true,
                   "type": "string"
                },
@@ -852,7 +863,7 @@
                   "type": "string"
                },
                "projectId": {
-                  "example": "project-12345",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "readOnly": true,
                   "type": "string"
                },
@@ -1009,7 +1020,7 @@
                   "type": "string"
                },
                "projectId": {
-                  "example": "project-12345",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "readOnly": true,
                   "type": "string"
                },
@@ -1117,7 +1128,7 @@
                   "type": "string"
                },
                "projectId": {
-                  "example": "project-12345",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "readOnly": true,
                   "type": "string"
                },
@@ -1131,7 +1142,7 @@
                   "type": "string"
                },
                "taskId": {
-                  "example": "task-12345",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "readOnly": true,
                   "type": "string"
                },
@@ -1560,6 +1571,9 @@
                },
                "format": {
                   "type": "string"
+               },
+               "params": {
+                  "$ref": "#/components/schemas/AlgorithmParameterSpec"
                }
             },
             "type": "object"
@@ -1650,7 +1664,7 @@
                   "$ref": "#/components/schemas/Instant"
                },
                "eventId": {
-                  "example": "event-13",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "type": "string"
                },
                "instanceId": {
@@ -1660,7 +1674,7 @@
                   "$ref": "#/components/schemas/InstanceLabels"
                },
                "jobId": {
-                  "example": "job-12345",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "type": "string"
                },
                "status": {
@@ -1707,6 +1721,7 @@
                "AZURE_US_SOUTHCENTRAL",
                "AZURE_EU_NORTH",
                "RC_ICELAND_1",
+               "COREWEAVE_US_EAST_4",
                "UNASSIGNED"
             ],
             "type": "string"
@@ -1992,7 +2007,7 @@
       }
    },
    "info": {
-      "description": "### Changelog\n#### 2024-12-23\n- Added an improvement to job scheduling that splits up batches for limit constrained job submit requests (ENK-2340)\n#### 2024-11-05\n- Added the project_name label to project level metrics that were previously missing it (ENK-2256)\n- Automatically delete jobs sixty days after they reach a terminal state (ENK-2137)\n#### 2024-10-15\n- Fixed an issue where non-existent images would incorrectly return a PENDING status instead of a 404 response when checking image availability across cloud providers. (ENK-1139)\n#### 2024-10-07\n- Added improvements and optimizations for GCP image validation on job submit. (ENK-2158)\n#### 2024-10-02\n- Added improvements and optimizations for processing job submit requests in limited projects and workspaces. (ENK-1844)\n#### 2024-09-10\n- Added additional validation for the HTCJobDefinition during job submission. (ENK-2155)\n#### 2024-09-09\n- Added additional metrics for vCPU scheduling. (ENK-2039)\n#### 2024-08-26\n- Added additional metrics for swap and disk usage. (ENK-2023, ENK-2044, ENK-2045, ENK-2120)\n#### 2024-08-19\n- Added support for jobs in GCP to use the experimental real swap feature for workspaces where swap infrastructure has been configured. The amount of swap provided is approximately equal to the memory requested by the job. This feature can be enabled by setting the experimental.kubernetesSwap field to true in the Job submit request (ENK-2065)\n#### 2024-08-14\n- Updated job cancellation to correctly update job status. (ENK-2069)\n#### 2024-08-09\n- Updated the response from `/htc/gcp/clusters/{workspaceId}` to include the cluster's autoscaling profile and subnetwork name. (ENK-2042)\n#### 2024-07-22\n- Fixed issue where jobs in multi-region projects were all getting routed to a single region instead of being spread out\n#### 2024-07-18\n- Added htc_job_limit_vcpus metric to response from /htc/metrics\n#### 2024-07-08\n- Allow workspace and organization admin to cancel jobs, view job logs and view job events\n#### 2024-04-23\n- Workspaces can now also be configured with a task retention policy which governs the auto-archival and auto-deletion of tasks. The project task retention policy is prioritized.\n#### 2024-03-01\n- Projects can now be configured with a task retention policy which governs the auto-archival and auto-deletion of tasks.\n- The API now supports manual archival of tasks.\n#### 2024-01-31\n- Added pagination support for GET /htc/projects/{projectId}/tasks/{taskId}/groups endpoint.\n#### 2024-01-26\n- Added workspace dimensions endpoint to enable viewing of predefined computing environment options for a workspace.\n- Added project dimensions endpoints to enable inspection of a project's current computing environment configuration as well as facilitate customization and adjustment of a project's computing environment settings.\n#### 2023-09-25\n- Introduced new `/limits` API endpoints for resource limit management at workspace and project levels.\n- If limits are set for both workspace and project, jobs within the project may be throttled based on resource consumption across either.\n#### 2023-06-20\n- Do not allow jobs submission to deleted tasks \n#### 2023-05-05\n- Fixed issue where jobs would be stuck in running despite completing successfully \n#### 2023-04-20\n- Added clearer error messages for jobs that failed because they exceeded disk space limits \n#### 2023-04-06\n- Added support for validating HTC Bearer tokens using JWKs \n#### 2023-03-07\n- Added support for adding user-defined claims to job bearer tokens during job submission\n- Limited the scope of API endpoints that job bearer tokens are allowed to access \n#### 2023-01-10\n- Added support for extending an existing project with additional regions.\n- Note: this does not currently consolidate images and objects in storage to new regions.\n#### 2022-11-30\n- Updated maxSwap minimum value to 0.\n- If maxSwap is 0 it will not be set in the job definition.\n#### 2022-11-23\n- Changed maxDiskGb field to maxDiskGiB. Fix GCP to use MiB and GiB instead of MB and GB to be consistent with AWS.  \n#### 2022-11-21\n- Updated job submit request body to allow maxDiskGb to be optionally set by the user for GCP only. \n#### 2022-11-18\n- Updated job submit request body to include only maxSwap to be optionally set by user. See HTCJobDefinition model for more details.\n- maxSwap defaults to 2000MB if no value is provided.\n- maxSwap is currently only supported on AWS.\n#### 2022-10-17\n- Added endpoint to return group names associated with a task.\n#### 2022-08-01\n - Added validation for system environment variables during job submission.\n#### 2022-07-25\n - Added support for image tags on GCP. Images pushed to ECR with a tag will be replicated with the tag attached to GCP, and can be submitted in the same way as AWS\n- Resolved bug where log lines were duplicated several times.\n#### 2022-07-08\n - Added validation for image name during job submission\n#### 2022-06-30\n - Added capability to run AARCH64 jobs (specified on the job definition endpoint) on <em>GCP_US_CENTRAL_1</em> and <em>GCP_EU_WEST_4</em> for all users.\n- Added capability to run jobs in GCP region <em>GCP_US_CENTRAL_1</em> for all users.\n#### 2022-06-23\n - Added capability to run jobs in GCP region <em>GCP_EU_WEST_4</em> for all users. This is set during project creation.",
+      "description": "### Changelog\n#### 2025-03-10\n- Updated documentation around swap, deprecated the maxSwap parameter in HTCJobSubmitRequest (ENK-2467)\n#### 2024-12-23\n- Added an improvement to job scheduling that splits up batches for limit constrained job submit requests (ENK-2340)\n#### 2024-11-05\n- Added the project_name label to project level metrics that were previously missing it (ENK-2256)\n- Automatically delete jobs sixty days after they reach a terminal state (ENK-2137)\n#### 2024-10-15\n- Fixed an issue where non-existent images would incorrectly return a PENDING status instead of a 404 response when checking image availability across cloud providers. (ENK-1139)\n#### 2024-10-07\n- Added improvements and optimizations for GCP image validation on job submit. (ENK-2158)\n#### 2024-10-02\n- Added improvements and optimizations for processing job submit requests in limited projects and workspaces. (ENK-1844)\n#### 2024-09-10\n- Added additional validation for the HTCJobDefinition during job submission. (ENK-2155)\n#### 2024-09-09\n- Added additional metrics for vCPU scheduling. (ENK-2039)\n#### 2024-08-26\n- Added additional metrics for swap and disk usage. (ENK-2023, ENK-2044, ENK-2045, ENK-2120)\n#### 2024-08-19\n- Added support for jobs in GCP to use the experimental real swap feature for workspaces where swap infrastructure has been configured. The amount of swap provided is approximately equal to the memory requested by the job. This feature can be enabled by setting the experimental.kubernetesSwap field to true in the Job submit request (ENK-2065)\n#### 2024-08-14\n- Updated job cancellation to correctly update job status. (ENK-2069)\n#### 2024-08-09\n- Updated the response from `/htc/gcp/clusters/{workspaceId}` to include the cluster's autoscaling profile and subnetwork name. (ENK-2042)\n#### 2024-07-22\n- Fixed issue where jobs in multi-region projects were all getting routed to a single region instead of being spread out\n#### 2024-07-18\n- Added htc_job_limit_vcpus metric to response from /htc/metrics\n#### 2024-07-08\n- Allow workspace and organization admin to cancel jobs, view job logs and view job events\n#### 2024-04-23\n- Workspaces can now also be configured with a task retention policy which governs the auto-archival and auto-deletion of tasks. The project task retention policy is prioritized.\n#### 2024-03-01\n- Projects can now be configured with a task retention policy which governs the auto-archival and auto-deletion of tasks.\n- The API now supports manual archival of tasks.\n#### 2024-01-31\n- Added pagination support for GET /htc/projects/{projectId}/tasks/{taskId}/groups endpoint.\n#### 2024-01-26\n- Added workspace dimensions endpoint to enable viewing of predefined computing environment options for a workspace.\n- Added project dimensions endpoints to enable inspection of a project's current computing environment configuration as well as facilitate customization and adjustment of a project's computing environment settings.\n#### 2023-09-25\n- Introduced new `/limits` API endpoints for resource limit management at workspace and project levels.\n- If limits are set for both workspace and project, jobs within the project may be throttled based on resource consumption across either.\n#### 2023-06-20\n- Do not allow jobs submission to deleted tasks \n#### 2023-05-05\n- Fixed issue where jobs would be stuck in running despite completing successfully \n#### 2023-04-20\n- Added clearer error messages for jobs that failed because they exceeded disk space limits \n#### 2023-04-06\n- Added support for validating HTC Bearer tokens using JWKs \n#### 2023-03-07\n- Added support for adding user-defined claims to job bearer tokens during job submission\n- Limited the scope of API endpoints that job bearer tokens are allowed to access \n#### 2023-01-10\n- Added support for extending an existing project with additional regions.\n- Note: this does not currently consolidate images and objects in storage to new regions.\n#### 2022-11-30\n- Updated maxSwap minimum value to 0.\n- If maxSwap is 0 it will not be set in the job definition.\n#### 2022-11-23\n- Changed maxDiskGb field to maxDiskGiB. Fix GCP to use MiB and GiB instead of MB and GB to be consistent with AWS.  \n#### 2022-11-21\n- Updated job submit request body to allow maxDiskGb to be optionally set by the user for GCP only. \n#### 2022-11-18\n- Updated job submit request body to include only maxSwap to be optionally set by user. See HTCJobDefinition model for more details.\n- maxSwap defaults to 2000MB if no value is provided.\n- maxSwap is currently only supported on AWS.\n#### 2022-10-17\n- Added endpoint to return group names associated with a task.\n#### 2022-08-01\n - Added validation for system environment variables during job submission.\n#### 2022-07-25\n - Added support for image tags on GCP. Images pushed to ECR with a tag will be replicated with the tag attached to GCP, and can be submitted in the same way as AWS\n- Resolved bug where log lines were duplicated several times.\n#### 2022-07-08\n - Added validation for image name during job submission\n#### 2022-06-30\n - Added capability to run AARCH64 jobs (specified on the job definition endpoint) on <em>GCP_US_CENTRAL_1</em> and <em>GCP_EU_WEST_4</em> for all users.\n- Added capability to run jobs in GCP region <em>GCP_US_CENTRAL_1</em> for all users.\n#### 2022-06-23\n - Added capability to run jobs in GCP region <em>GCP_EU_WEST_4</em> for all users. This is set during project creation.",
       "title": "Rescale HTC API",
       "version": "Beta V1"
    },
@@ -2005,6 +2020,23 @@
                "200": {
                   "content": {
                      "application/json": {
+                        "examples": {
+                           "jwks": {
+                              "summary": "Sample JWK Set",
+                              "value": {
+                                 "keys": [
+                                    {
+                                       "alg": "RS256",
+                                       "e": "AQAB",
+                                       "kid": "c0dc8eda-e0db-4882-901e-1862c3860550",
+                                       "kty": "RSA",
+                                       "n": "rsa-public-modulus",
+                                       "use": "sig"
+                                    }
+                                 ]
+                              }
+                           }
+                        },
                         "schema": {
                            "$ref": "#/components/schemas/JsonWebKeySet"
                         }
@@ -2033,6 +2065,16 @@
          "get": {
             "description": "This endpoint will get a JWT token given an API key",
             "operationId": "getToken",
+            "parameters": [
+               {
+                  "in": "header",
+                  "name": "X-Rescale-Environment",
+                  "schema": {
+                     "default": "prod",
+                     "type": "string"
+                  }
+               }
+            ],
             "responses": {
                "200": {
                   "content": {
@@ -2382,6 +2424,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -2432,6 +2484,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -2475,6 +2537,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -2603,6 +2675,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -2648,6 +2730,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -2692,6 +2784,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -2748,6 +2850,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -2783,6 +2895,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -2824,6 +2946,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -2874,6 +3006,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -2918,6 +3060,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -2967,6 +3119,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3025,6 +3187,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3076,6 +3248,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3118,6 +3300,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3168,6 +3360,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3210,6 +3412,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3245,6 +3457,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3285,6 +3507,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3334,6 +3566,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3393,6 +3635,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3444,6 +3696,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3542,7 +3804,7 @@
                                  "type": "string"
                               },
                               "projectId": {
-                                 "example": "project-12345",
+                                 "example": "123e4567-e89b-12d3-a456-426614174000",
                                  "readOnly": true,
                                  "type": "string"
                               },
@@ -3556,7 +3818,7 @@
                                  "type": "string"
                               },
                               "taskId": {
-                                 "example": "task-12345",
+                                 "example": "123e4567-e89b-12d3-a456-426614174000",
                                  "readOnly": true,
                                  "type": "string"
                               },
@@ -3585,6 +3847,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3633,6 +3905,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3690,6 +3972,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3778,6 +4070,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3851,6 +4153,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -3960,7 +4272,8 @@
                            "$ref": "#/components/schemas/HTCRequestError"
                         }
                      }
-                  }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4044,6 +4357,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4097,6 +4420,10 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": { },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4253,6 +4580,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4310,6 +4647,19 @@
                      "default": 100,
                      "format": "int32",
                      "type": "integer"
+                  }
+               },
+               {
+                  "description": "Sort order",
+                  "in": "query",
+                  "name": "sort",
+                  "schema": {
+                     "default": "desc",
+                     "enum": [
+                        "asc",
+                        "desc"
+                     ],
+                     "type": "string"
                   }
                }
             ],
@@ -4398,6 +4748,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4448,6 +4808,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4498,6 +4868,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4556,6 +4936,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4606,6 +4996,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4656,6 +5056,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4843,6 +5253,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4888,6 +5308,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4930,6 +5360,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -4972,6 +5412,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -5021,6 +5471,16 @@
                },
                "403": {
                   "description": "Not Allowed"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/OAuth2ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Not Found"
                }
             },
             "security": [
@@ -5068,7 +5528,7 @@
    },
    "servers": [
       {
-         "url": "https://htc.rescale.com/api/v1"
+         "url": "http://localhost:8080/api/v1"
       }
    ]
 }

--- a/v2/api/swagger.json
+++ b/v2/api/swagger.json
@@ -6,7 +6,7 @@
     "version" : "Beta V1"
   },
   "servers" : [ {
-    "url" : "http://localhost:8080/api/v1"
+    "url" : "https://htc.rescale.com/api/v1"
   } ],
   "paths" : {
     "/.well-known/jwks.json" : {
@@ -3128,9 +3128,6 @@
   },
   "components" : {
     "schemas" : {
-      "AlgorithmParameterSpec" : {
-        "type" : "object"
-      },
       "Architecture" : {
         "enum" : [ "AARCH64", "X86", "A100" ],
         "type" : "string"
@@ -4426,9 +4423,6 @@
       "PublicKey" : {
         "type" : "object",
         "properties" : {
-          "params" : {
-            "$ref" : "#/components/schemas/AlgorithmParameterSpec"
-          },
           "algorithm" : {
             "type" : "string"
           },

--- a/v2/api/swagger.json
+++ b/v2/api/swagger.json
@@ -2,11 +2,11 @@
   "openapi" : "3.0.3",
   "info" : {
     "title" : "Rescale HTC API",
-    "description" : "### Changelog\n#### 2024-12-23\n- Added an improvement to job scheduling that splits up batches for limit constrained job submit requests (ENK-2340)\n#### 2024-11-05\n- Added the project_name label to project level metrics that were previously missing it (ENK-2256)\n- Automatically delete jobs sixty days after they reach a terminal state (ENK-2137)\n#### 2024-10-15\n- Fixed an issue where non-existent images would incorrectly return a PENDING status instead of a 404 response when checking image availability across cloud providers. (ENK-1139)\n#### 2024-10-07\n- Added improvements and optimizations for GCP image validation on job submit. (ENK-2158)\n#### 2024-10-02\n- Added improvements and optimizations for processing job submit requests in limited projects and workspaces. (ENK-1844)\n#### 2024-09-10\n- Added additional validation for the HTCJobDefinition during job submission. (ENK-2155)\n#### 2024-09-09\n- Added additional metrics for vCPU scheduling. (ENK-2039)\n#### 2024-08-26\n- Added additional metrics for swap and disk usage. (ENK-2023, ENK-2044, ENK-2045, ENK-2120)\n#### 2024-08-19\n- Added support for jobs in GCP to use the experimental real swap feature for workspaces where swap infrastructure has been configured. The amount of swap provided is approximately equal to the memory requested by the job. This feature can be enabled by setting the experimental.kubernetesSwap field to true in the Job submit request (ENK-2065)\n#### 2024-08-14\n- Updated job cancellation to correctly update job status. (ENK-2069)\n#### 2024-08-09\n- Updated the response from `/htc/gcp/clusters/{workspaceId}` to include the cluster's autoscaling profile and subnetwork name. (ENK-2042)\n#### 2024-07-22\n- Fixed issue where jobs in multi-region projects were all getting routed to a single region instead of being spread out\n#### 2024-07-18\n- Added htc_job_limit_vcpus metric to response from /htc/metrics\n#### 2024-07-08\n- Allow workspace and organization admin to cancel jobs, view job logs and view job events\n#### 2024-04-23\n- Workspaces can now also be configured with a task retention policy which governs the auto-archival and auto-deletion of tasks. The project task retention policy is prioritized.\n#### 2024-03-01\n- Projects can now be configured with a task retention policy which governs the auto-archival and auto-deletion of tasks.\n- The API now supports manual archival of tasks.\n#### 2024-01-31\n- Added pagination support for GET /htc/projects/{projectId}/tasks/{taskId}/groups endpoint.\n#### 2024-01-26\n- Added workspace dimensions endpoint to enable viewing of predefined computing environment options for a workspace.\n- Added project dimensions endpoints to enable inspection of a project's current computing environment configuration as well as facilitate customization and adjustment of a project's computing environment settings.\n#### 2023-09-25\n- Introduced new `/limits` API endpoints for resource limit management at workspace and project levels.\n- If limits are set for both workspace and project, jobs within the project may be throttled based on resource consumption across either.\n#### 2023-06-20\n- Do not allow jobs submission to deleted tasks \n#### 2023-05-05\n- Fixed issue where jobs would be stuck in running despite completing successfully \n#### 2023-04-20\n- Added clearer error messages for jobs that failed because they exceeded disk space limits \n#### 2023-04-06\n- Added support for validating HTC Bearer tokens using JWKs \n#### 2023-03-07\n- Added support for adding user-defined claims to job bearer tokens during job submission\n- Limited the scope of API endpoints that job bearer tokens are allowed to access \n#### 2023-01-10\n- Added support for extending an existing project with additional regions.\n- Note: this does not currently consolidate images and objects in storage to new regions.\n#### 2022-11-30\n- Updated maxSwap minimum value to 0.\n- If maxSwap is 0 it will not be set in the job definition.\n#### 2022-11-23\n- Changed maxDiskGb field to maxDiskGiB. Fix GCP to use MiB and GiB instead of MB and GB to be consistent with AWS.  \n#### 2022-11-21\n- Updated job submit request body to allow maxDiskGb to be optionally set by the user for GCP only. \n#### 2022-11-18\n- Updated job submit request body to include only maxSwap to be optionally set by user. See HTCJobDefinition model for more details.\n- maxSwap defaults to 2000MB if no value is provided.\n- maxSwap is currently only supported on AWS.\n#### 2022-10-17\n- Added endpoint to return group names associated with a task.\n#### 2022-08-01\n - Added validation for system environment variables during job submission.\n#### 2022-07-25\n - Added support for image tags on GCP. Images pushed to ECR with a tag will be replicated with the tag attached to GCP, and can be submitted in the same way as AWS\n- Resolved bug where log lines were duplicated several times.\n#### 2022-07-08\n - Added validation for image name during job submission\n#### 2022-06-30\n - Added capability to run AARCH64 jobs (specified on the job definition endpoint) on <em>GCP_US_CENTRAL_1</em> and <em>GCP_EU_WEST_4</em> for all users.\n- Added capability to run jobs in GCP region <em>GCP_US_CENTRAL_1</em> for all users.\n#### 2022-06-23\n - Added capability to run jobs in GCP region <em>GCP_EU_WEST_4</em> for all users. This is set during project creation.",
+    "description" : "### Changelog\n#### 2025-03-10\n- Updated documentation around swap, deprecated the maxSwap parameter in HTCJobSubmitRequest (ENK-2467)\n#### 2024-12-23\n- Added an improvement to job scheduling that splits up batches for limit constrained job submit requests (ENK-2340)\n#### 2024-11-05\n- Added the project_name label to project level metrics that were previously missing it (ENK-2256)\n- Automatically delete jobs sixty days after they reach a terminal state (ENK-2137)\n#### 2024-10-15\n- Fixed an issue where non-existent images would incorrectly return a PENDING status instead of a 404 response when checking image availability across cloud providers. (ENK-1139)\n#### 2024-10-07\n- Added improvements and optimizations for GCP image validation on job submit. (ENK-2158)\n#### 2024-10-02\n- Added improvements and optimizations for processing job submit requests in limited projects and workspaces. (ENK-1844)\n#### 2024-09-10\n- Added additional validation for the HTCJobDefinition during job submission. (ENK-2155)\n#### 2024-09-09\n- Added additional metrics for vCPU scheduling. (ENK-2039)\n#### 2024-08-26\n- Added additional metrics for swap and disk usage. (ENK-2023, ENK-2044, ENK-2045, ENK-2120)\n#### 2024-08-19\n- Added support for jobs in GCP to use the experimental real swap feature for workspaces where swap infrastructure has been configured. The amount of swap provided is approximately equal to the memory requested by the job. This feature can be enabled by setting the experimental.kubernetesSwap field to true in the Job submit request (ENK-2065)\n#### 2024-08-14\n- Updated job cancellation to correctly update job status. (ENK-2069)\n#### 2024-08-09\n- Updated the response from `/htc/gcp/clusters/{workspaceId}` to include the cluster's autoscaling profile and subnetwork name. (ENK-2042)\n#### 2024-07-22\n- Fixed issue where jobs in multi-region projects were all getting routed to a single region instead of being spread out\n#### 2024-07-18\n- Added htc_job_limit_vcpus metric to response from /htc/metrics\n#### 2024-07-08\n- Allow workspace and organization admin to cancel jobs, view job logs and view job events\n#### 2024-04-23\n- Workspaces can now also be configured with a task retention policy which governs the auto-archival and auto-deletion of tasks. The project task retention policy is prioritized.\n#### 2024-03-01\n- Projects can now be configured with a task retention policy which governs the auto-archival and auto-deletion of tasks.\n- The API now supports manual archival of tasks.\n#### 2024-01-31\n- Added pagination support for GET /htc/projects/{projectId}/tasks/{taskId}/groups endpoint.\n#### 2024-01-26\n- Added workspace dimensions endpoint to enable viewing of predefined computing environment options for a workspace.\n- Added project dimensions endpoints to enable inspection of a project's current computing environment configuration as well as facilitate customization and adjustment of a project's computing environment settings.\n#### 2023-09-25\n- Introduced new `/limits` API endpoints for resource limit management at workspace and project levels.\n- If limits are set for both workspace and project, jobs within the project may be throttled based on resource consumption across either.\n#### 2023-06-20\n- Do not allow jobs submission to deleted tasks \n#### 2023-05-05\n- Fixed issue where jobs would be stuck in running despite completing successfully \n#### 2023-04-20\n- Added clearer error messages for jobs that failed because they exceeded disk space limits \n#### 2023-04-06\n- Added support for validating HTC Bearer tokens using JWKs \n#### 2023-03-07\n- Added support for adding user-defined claims to job bearer tokens during job submission\n- Limited the scope of API endpoints that job bearer tokens are allowed to access \n#### 2023-01-10\n- Added support for extending an existing project with additional regions.\n- Note: this does not currently consolidate images and objects in storage to new regions.\n#### 2022-11-30\n- Updated maxSwap minimum value to 0.\n- If maxSwap is 0 it will not be set in the job definition.\n#### 2022-11-23\n- Changed maxDiskGb field to maxDiskGiB. Fix GCP to use MiB and GiB instead of MB and GB to be consistent with AWS.  \n#### 2022-11-21\n- Updated job submit request body to allow maxDiskGb to be optionally set by the user for GCP only. \n#### 2022-11-18\n- Updated job submit request body to include only maxSwap to be optionally set by user. See HTCJobDefinition model for more details.\n- maxSwap defaults to 2000MB if no value is provided.\n- maxSwap is currently only supported on AWS.\n#### 2022-10-17\n- Added endpoint to return group names associated with a task.\n#### 2022-08-01\n - Added validation for system environment variables during job submission.\n#### 2022-07-25\n - Added support for image tags on GCP. Images pushed to ECR with a tag will be replicated with the tag attached to GCP, and can be submitted in the same way as AWS\n- Resolved bug where log lines were duplicated several times.\n#### 2022-07-08\n - Added validation for image name during job submission\n#### 2022-06-30\n - Added capability to run AARCH64 jobs (specified on the job definition endpoint) on <em>GCP_US_CENTRAL_1</em> and <em>GCP_EU_WEST_4</em> for all users.\n- Added capability to run jobs in GCP region <em>GCP_US_CENTRAL_1</em> for all users.\n#### 2022-06-23\n - Added capability to run jobs in GCP region <em>GCP_EU_WEST_4</em> for all users. This is set during project creation.",
     "version" : "Beta V1"
   },
   "servers" : [ {
-    "url" : "https://htc.rescale.com/api/v1"
+    "url" : "http://localhost:8080/api/v1"
   } ],
   "paths" : {
     "/.well-known/jwks.json" : {
@@ -21,6 +21,21 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/JsonWebKeySet"
+                },
+                "examples" : {
+                  "jwks" : {
+                    "summary" : "Sample JWK Set",
+                    "value" : {
+                      "keys" : [ {
+                        "kty" : "RSA",
+                        "kid" : "c0dc8eda-e0db-4882-901e-1862c3860550",
+                        "use" : "sig",
+                        "alg" : "RS256",
+                        "n" : "rsa-public-modulus",
+                        "e" : "AQAB"
+                      } ]
+                    }
+                  }
                 }
               }
             }
@@ -115,14 +130,6 @@
         "tags" : [ "Token Resource" ],
         "summary" : "Get Rescale User",
         "description" : "This endpoint will get Rescale user information given a Rescale API key.",
-        "parameters" : [ {
-          "name" : "X-Rescale-Environment",
-          "in" : "header",
-          "schema" : {
-            "default" : "prod",
-            "type" : "string"
-          }
-        } ],
         "responses" : {
           "200" : {
             "description" : "Ok",
@@ -191,11 +198,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -230,11 +237,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -291,11 +298,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -326,11 +333,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -362,11 +369,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -405,11 +422,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -441,11 +468,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -506,11 +543,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -551,11 +588,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -588,11 +635,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -627,11 +684,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -676,11 +743,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -715,11 +792,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -758,11 +845,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -785,11 +882,21 @@
           "204" : {
             "description" : "No Content"
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -829,11 +936,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -864,11 +981,21 @@
           "204" : {
             "description" : "No Content"
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -915,11 +1042,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -959,11 +1096,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -995,11 +1142,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1038,11 +1195,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1074,11 +1241,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1110,11 +1287,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1153,11 +1340,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1180,11 +1377,21 @@
           "204" : {
             "description" : "No Content"
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1242,11 +1449,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1285,11 +1502,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1328,11 +1555,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1370,12 +1607,12 @@
                     "projectId" : {
                       "type" : "string",
                       "readOnly" : true,
-                      "example" : "project-12345"
+                      "example" : "123e4567-e89b-12d3-a456-426614174000"
                     },
                     "taskId" : {
                       "type" : "string",
                       "readOnly" : true,
-                      "example" : "task-12345"
+                      "example" : "123e4567-e89b-12d3-a456-426614174000"
                     },
                     "taskName" : {
                       "type" : "string",
@@ -1442,11 +1679,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1492,11 +1739,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1570,11 +1827,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1631,11 +1898,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1730,11 +2007,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1797,11 +2084,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1840,11 +2137,15 @@
           "200" : {
             "description" : "Ok"
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : { }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1890,11 +2191,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1966,11 +2277,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2019,6 +2340,15 @@
             "default" : 100,
             "type" : "integer"
           }
+        }, {
+          "name" : "sort",
+          "in" : "query",
+          "description" : "Sort order",
+          "schema" : {
+            "default" : "desc",
+            "enum" : [ "asc", "desc" ],
+            "type" : "string"
+          }
         } ],
         "responses" : {
           "200" : {
@@ -2043,11 +2373,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2094,11 +2434,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2137,11 +2487,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2180,11 +2540,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2230,11 +2600,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2273,11 +2653,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2316,11 +2706,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2367,11 +2767,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2413,11 +2813,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2444,11 +2844,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2480,11 +2880,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2519,11 +2929,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2555,11 +2975,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2591,11 +3021,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2634,11 +3074,21 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OAuth2ErrorResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -2678,6 +3128,9 @@
   },
   "components" : {
     "schemas" : {
+      "AlgorithmParameterSpec" : {
+        "type" : "object"
+      },
       "Architecture" : {
         "enum" : [ "AARCH64", "X86", "A100" ],
         "type" : "string"
@@ -2703,7 +3156,7 @@
         "type" : "string"
       },
       "CloudProvider" : {
-        "enum" : [ "AWS", "GCP", "NGC", "AZURE", "RC", "UNASSIGNED" ],
+        "enum" : [ "AWS", "GCP", "NGC", "AZURE", "RC", "COREWEAVE", "UNASSIGNED" ],
         "type" : "string"
       },
       "ContainerDetails" : {
@@ -2750,7 +3203,7 @@
         "type" : "object",
         "properties" : {
           "name" : {
-            "pattern": "^(?!.*AWS_BATCH_|RESCALE_PROJECT_ID|RESCALE_TASK_ID|RESCALE_JOB_ID|PROJECT_SHARED_FOLDER|TASK_SHARED_FOLDER|AWS_SESSION_TOKEN|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|RDF_).*",
+            "pattern" : "^(?!.*AWS_BATCH_|RESCALE_PROJECT_ID|RESCALE_TASK_ID|RESCALE_JOB_ID|PROJECT_SHARED_FOLDER|TASK_SHARED_FOLDER|AWS_SESSION_TOKEN|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|RDF_).*",
             "type" : "string",
             "example" : "FOO"
           },
@@ -2764,12 +3217,16 @@
         "type" : "object",
         "properties" : {
           "kubernetesSwap" : {
+            "description" : "Allows the job to use swap space equal to the amount of memory assigned. For example, a job with 128 MB of memory would also be allowed to use 128 MB of swap memory (disk)",
             "type" : "boolean"
           },
           "cloudFileSystems" : {
             "type" : "boolean"
           },
           "rescaleFilesRDFAgent" : {
+            "type" : "boolean"
+          },
+          "privilegedMode" : {
             "type" : "boolean"
           }
         }
@@ -2920,7 +3377,7 @@
         "properties" : {
           "jobUUID" : {
             "type" : "string",
-            "example" : "155f18d4"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "providerJobId" : {
             "type" : "string",
@@ -2931,11 +3388,11 @@
           },
           "taskId" : {
             "type" : "string",
-            "example" : "task-12345"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "projectId" : {
             "type" : "string",
-            "example" : "project-12345"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "status" : {
             "$ref" : "#/components/schemas/RescaleJobStatus"
@@ -3010,6 +3467,10 @@
             "format" : "int32",
             "type" : "integer"
           },
+          "maxGpus" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
           "imageName" : {
             "type" : "string"
           },
@@ -3072,7 +3533,7 @@
           },
           "maxSwap" : {
             "format" : "int32",
-            "description" : "On AWS, maxSwap allows swap memory to be used, up to the limit. On other providers, swap is not available, but maxSwap is added to the maxMemory to provide the same amount of available space. The default value is 2000 MB",
+            "description" : "Deprecated. This field has no effect and may be removed at any time.",
             "minimum" : 0,
             "type" : "integer"
           },
@@ -3093,9 +3554,22 @@
             "example" : [ "python", "script.py" ]
           },
           "envs" : {
+            "description" : "Must not be reserved environment variable:AWS_BATCH_CE_NAME |AWS_BATCH_JOB_ARRAY_INDEX |AWS_BATCH_JOB_ATTEMPT |AWS_BATCH_JOB_ID |AWS_BATCH_JOB_MAIN_NODE_INDEX |AWS_BATCH_JOB_MAIN_NODE_PRIVATE_IPV4_ADDRESS |AWS_BATCH_JOB_NODE_INDEX |AWS_BATCH_JOB_NUM_NODES |AWS_BATCH_JQ_NAME |RESCALE_PROJECT_ID |RESCALE_TASK_ID |RESCALE_JOB_ID |RESCALE_HTC_REGION |RESCALE_HTC_TASK_ID |RESCALE_HTC_PROJECT_ID |RESCALE_HTC_BEARER_TOKEN |PROJECT_SHARED_FOLDER |TASK_SHARED_FOLDER |AWS_SESSION_TOKEN |AWS_ACCESS_KEY_ID |AWS_SECRET_ACCESS_KEY",
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/EnvPair"
+              "required" : [ "name", "value" ],
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "pattern" : "^(?!.*AWS_BATCH_|RESCALE_PROJECT_ID|RESCALE_TASK_ID|RESCALE_JOB_ID|PROJECT_SHARED_FOLDER|TASK_SHARED_FOLDER|AWS_SESSION_TOKEN|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|RDF_).*",
+                  "type" : "string",
+                  "example" : "FOO"
+                },
+                "value" : {
+                  "type" : "string",
+                  "example" : "bar"
+                }
+              }
             }
           },
           "claims" : {
@@ -3115,7 +3589,11 @@
             "$ref" : "#/components/schemas/Architecture"
           },
           "priority" : {
-            "$ref" : "#/components/schemas/JobPriority"
+            "description" : "ON_DEMAND_ECONOMY uses spot instances and may be preempted.",
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/JobPriority"
+            } ]
           },
           "workingDir" : {
             "description" : "",
@@ -3138,17 +3616,17 @@
           "taskId" : {
             "type" : "string",
             "readOnly" : true,
-            "example" : "task-12345"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "projectId" : {
             "type" : "string",
             "readOnly" : true,
-            "example" : "project-12345"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "parentJobId" : {
             "type" : "string",
             "readOnly" : true,
-            "example" : "job-12345"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "createdBy" : {
             "type" : "string",
@@ -3277,7 +3755,7 @@
           "projectId" : {
             "type" : "string",
             "readOnly" : true,
-            "example" : "project-12345"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "projectName" : {
             "type" : "string",
@@ -3392,7 +3870,7 @@
           "projectId" : {
             "type" : "string",
             "readOnly" : true,
-            "example" : "project-12345"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "modifierRole" : {
             "description" : "The highest role that can modify this limit",
@@ -3500,7 +3978,7 @@
           "projectId" : {
             "type" : "string",
             "readOnly" : true,
-            "example" : "project-12345"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "createdBy" : {
             "type" : "string",
@@ -3537,12 +4015,12 @@
           "projectId" : {
             "type" : "string",
             "readOnly" : true,
-            "example" : "project-12345"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "taskId" : {
             "type" : "string",
             "readOnly" : true,
-            "example" : "task-12345"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "taskName" : {
             "type" : "string",
@@ -3948,6 +4426,9 @@
       "PublicKey" : {
         "type" : "object",
         "properties" : {
+          "params" : {
+            "$ref" : "#/components/schemas/AlgorithmParameterSpec"
+          },
           "algorithm" : {
             "type" : "string"
           },
@@ -4032,11 +4513,11 @@
         "properties" : {
           "eventId" : {
             "type" : "string",
-            "example" : "event-13"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "jobId" : {
             "type" : "string",
-            "example" : "job-12345"
+            "example" : "123e4567-e89b-12d3-a456-426614174000"
           },
           "dateTime" : {
             "$ref" : "#/components/schemas/Instant"
@@ -4063,7 +4544,7 @@
         }
       },
       "RescaleRegion" : {
-        "enum" : [ "AWS_AP_SOUTHEAST_1", "AWS_CA_CENTRAL_1", "AWS_EU_NORTH_1", "AWS_EU_CENTRAL_1", "AWS_EU_WEST_1", "AWS_EU_WEST_2", "AWS_EU_WEST_3", "AWS_SA_EAST_1", "AWS_US_EAST_2", "AWS_US_WEST_2", "AWS_US_EAST_1", "GCP_ASIA_SOUTHEAST_1", "GCP_US_CENTRAL_1", "GCP_US_EAST_1", "GCP_US_EAST_2", "GCP_US_EAST_4", "GCP_US_WEST_1", "GCP_US_WEST_4", "GCP_EU_WEST_1", "GCP_EU_WEST_2", "GCP_EU_WEST_3", "GCP_EU_WEST_4", "GCP_CA_CENTRAL_1", "NGC_ENOCH_1", "AZURE_US_WEST_2", "AZURE_US_EAST_2", "AZURE_US_SOUTHCENTRAL", "AZURE_EU_NORTH", "RC_ICELAND_1", "UNASSIGNED" ],
+        "enum" : [ "AWS_AP_SOUTHEAST_1", "AWS_CA_CENTRAL_1", "AWS_EU_NORTH_1", "AWS_EU_CENTRAL_1", "AWS_EU_WEST_1", "AWS_EU_WEST_2", "AWS_EU_WEST_3", "AWS_SA_EAST_1", "AWS_US_EAST_2", "AWS_US_WEST_2", "AWS_US_EAST_1", "GCP_ASIA_SOUTHEAST_1", "GCP_US_CENTRAL_1", "GCP_US_EAST_1", "GCP_US_EAST_2", "GCP_US_EAST_4", "GCP_US_WEST_1", "GCP_US_WEST_4", "GCP_EU_WEST_1", "GCP_EU_WEST_2", "GCP_EU_WEST_3", "GCP_EU_WEST_4", "GCP_CA_CENTRAL_1", "NGC_ENOCH_1", "AZURE_US_WEST_2", "AZURE_US_EAST_2", "AZURE_US_SOUTHCENTRAL", "AZURE_EU_NORTH", "RC_ICELAND_1", "COREWEAVE_US_EAST_4", "UNASSIGNED" ],
         "type" : "string"
       },
       "RescaleUser" : {

--- a/v2/api/swagger.jsonnet
+++ b/v2/api/swagger.jsonnet
@@ -103,6 +103,15 @@ local patches = {
       get+: {
         'x-ogen-operation-group': 'Image',
         operationId: 'getRegistryToken',
+        responses+: {
+          '404': {
+            content: {
+              'application/json': {
+                schema: { '$ref': '#/components/schemas/OAuth2ErrorResponse'}
+              }
+            }
+          }
+        }
       },
     },
     '/htc/projects/{projectId}/dimensions'+: {

--- a/v2/commands/job/submit.go
+++ b/v2/commands/job/submit.go
@@ -102,7 +102,7 @@ func Submit(cmd *cobra.Command, args []string) error {
 		for i := range req.batch {
 			for k, v := range envMap {
 				req.batch[i].HtcJobDefinition.Envs = append(req.batch[i].HtcJobDefinition.Envs,
-					oapi.EnvPair{Name: k, Value: v})
+					oapi.HTCJobDefinitionEnvsItem{Name: k, Value: v})
 			}
 		}
 	}
@@ -173,11 +173,9 @@ func init() {
 			MaxMemory:  oapi.NewOptInt32(128),
 			MaxDiskGiB: oapi.NewOptInt32(1),
 			Commands:   []string{"/bin/sh", "-c", "sleep 5m; echo all done"},
-			Envs: []oapi.EnvPair{
-				oapi.EnvPair{"INPUT_BUCKET", "htc-rescale-bucket"},
-			},
+			Envs: []oapi.HTCJobDefinitionEnvsItem{},
 			ExecTimeoutSeconds: oapi.NewOptInt32(3600),
-			Priority:           oapi.NewOptJobPriority(oapi.JobPriorityONDEMANDPRIORITY),
+			Priority:           oapi.NewOptHTCJobDefinitionPriority(oapi.HTCJobDefinitionPriorityONDEMANDPRIORITY),
 		},
 		BatchSize: oapi.NewOptInt32(1),
 		Regions: []oapi.RescaleRegion{

--- a/v2/common/constants.go
+++ b/v2/common/constants.go
@@ -1,8 +1,3 @@
 package common
 
-import (
-	"time"
-)
-
 const PageSize = 500
-const LogsQueryInterval = 5 * time.Second

--- a/v2/common/constants.go
+++ b/v2/common/constants.go
@@ -1,3 +1,8 @@
 package common
 
+import (
+	"time"
+)
+
 const PageSize = 500
+const LogsQueryInterval = 5 * time.Second

--- a/v2/common/runner.go
+++ b/v2/common/runner.go
@@ -56,7 +56,7 @@ func loadConfig(cmd *cobra.Command) (*config.Config, error) {
 }
 
 func getBearerToken(ctx context.Context, c *oapi.Client) (*oapi.HTCToken, error) {
-	res, err := c.GetToken(ctx)
+	res, err := c.GetToken(ctx, oapi.GetTokenParams{})
 	if err != nil {
 		log.Fatalf("Login failed: %s", err)
 	}


### PR DESCRIPTION
JIRA: https://rescale.atlassian.net/browse/ENK-2441
Summary:
- Adds -f flag to continuously check logs endpoint for new logs
- Depends on https://github.com/rescale/enki/pull/1098

# TODO
- [x] Add flag to return logs in asc order (API changes)
- [x] update server url in swagger.json from local once API changes merged.