### PR TITLE
ENK-2650: remaining workspace methods

### DIFF
--- a/v2/api/_oas/oas_client_gen.go
+++ b/v2/api/_oas/oas_client_gen.go
@@ -276,51 +276,6 @@ type Invoker interface {
 	//
 	// GET /htc/workspaces/{workspaceId}/dimensions
 	HtcWorkspacesWorkspaceIdDimensionsGet(ctx context.Context, params HtcWorkspacesWorkspaceIdDimensionsGetParams) (HtcWorkspacesWorkspaceIdDimensionsGetRes, error)
-	// HtcWorkspacesWorkspaceIdLimitsGet invokes GET /htc/workspaces/{workspaceId}/limits operation.
-	//
-	// This endpoint will get the resource limit applied to this workspace.
-	//
-	// GET /htc/workspaces/{workspaceId}/limits
-	HtcWorkspacesWorkspaceIdLimitsGet(ctx context.Context, params HtcWorkspacesWorkspaceIdLimitsGetParams) (HtcWorkspacesWorkspaceIdLimitsGetRes, error)
-	// HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet invokes GET /htc/workspaces/{workspaceId}/task-retention-policy operation.
-	//
-	// This endpoint is used to retrieve the current task retention policy of a specific Workspace. The
-	// task retention policy is necessary in managing the lifecycle of tasks within a Workspace. The task
-	// retention policy includes two key aspects:
-	// * **Deletion Grace Period**: The `deleteAfter` field represents the duration (in hours) after
-	// which an archived task is automatically deleted. Archived tasks can be unarchived during this
-	// period, protecting users from prematurely deleting task resources.
-	// * **Auto-Archive After Inactivity**: The `archiveAfter` field represents the duration (in hours)
-	// of inactivity after which an active task is automatically archived. This feature helps in keeping
-	// the project organized by archiving active tasks, ensuring that storage resources are freed
-	// optimistically.
-	// Setting either value to `0` will result in disabling of that feature. For example, a project's
-	// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
-	// auto-deleting.
-	//
-	// GET /htc/workspaces/{workspaceId}/task-retention-policy
-	HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet(ctx context.Context, params HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams) (HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes, error)
-	// HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut invokes PUT /htc/workspaces/{workspaceId}/task-retention-policy operation.
-	//
-	// This endpoint enables Workspace administrators to define or update the task retention policy for a
-	// specific workspace. The task retention policy includes two key aspects:
-	// * **Deletion Grace Period**: The `deleteAfter` field allows administrators to set the duration (in
-	// hours) after which an archived task is automatically deleted. This control allows for flexibility
-	// in managing the lifecycle of tasks, ensuring that data is retained for an adequate period before
-	// being permanently deleted. Archived tasks can be unarchived during this period, protecting users
-	// from prematurely deleting task resources
-	// * **Auto-Archive After Inactivity**: The `archiveAfter` field allows administrators to specify the
-	// duration (in hours) of inactivity after which an active task is automatically archived. This
-	// feature helps in keeping the project organized by archiving active tasks, ensuring that storage
-	// resources are freed optimistically.
-	// Setting either value to `0` will result in disabling of that feature. For example, a workspace's
-	// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
-	// auto-deleting. The policy applies to all projects within the workspace that do not have their own
-	// project-level policy defined. If a project within the workspace has its own retention policy
-	// defined, the project-level policy takes precedence over the workspace-level policy.
-	//
-	// PUT /htc/workspaces/{workspaceId}/task-retention-policy
-	HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut(ctx context.Context, request OptWorkspaceTaskRetentionPolicy, params HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams) (HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes, error)
 	// OAuth2TokenPost invokes POST /oauth2/token operation.
 	//
 	// This endpoint will get an OAuth access token.
@@ -473,20 +428,20 @@ type ProjectInvoker interface {
 	//
 	// GET /htc/projects/{projectId}/dimensions
 	GetDimensions(ctx context.Context, params GetDimensionsParams) (GetDimensionsRes, error)
-	// GetLimits invokes getLimits operation.
-	//
-	// This endpoint will list all resource limitations associated with this project.
-	// A job running in this project will be subject to all resulting limits as well as any associated
-	// with the workspace (see `/htc/workspaces/{workspaceId}/limits`).
-	//
-	// GET /htc/projects/{projectId}/limits
-	GetLimits(ctx context.Context, params GetLimitsParams) (GetLimitsRes, error)
 	// GetProject invokes getProject operation.
 	//
 	// This endpoint will get a project by id.
 	//
 	// GET /htc/projects/{projectId}
 	GetProject(ctx context.Context, params GetProjectParams) (GetProjectRes, error)
+	// GetProjectLimits invokes getProjectLimits operation.
+	//
+	// This endpoint will list all resource limitations associated with this project.
+	// A job running in this project will be subject to all resulting limits as well as any associated
+	// with the workspace (see `/htc/workspaces/{workspaceId}/limits`).
+	//
+	// GET /htc/projects/{projectId}/limits
+	GetProjectLimits(ctx context.Context, params GetProjectLimitsParams) (GetProjectLimitsRes, error)
 	// GetProjects invokes getProjects operation.
 	//
 	// This endpoint will get all projects.
@@ -530,6 +485,51 @@ type WorkspaceInvoker interface {
 	//
 	// GET /htc/gcp/clusters/{workspaceId}
 	GetGCPClusters(ctx context.Context, params GetGCPClustersParams) (GetGCPClustersRes, error)
+	// GetTaskRetentionPolicy invokes getTaskRetentionPolicy operation.
+	//
+	// This endpoint is used to retrieve the current task retention policy of a specific Workspace. The
+	// task retention policy is necessary in managing the lifecycle of tasks within a Workspace. The task
+	// retention policy includes two key aspects:
+	// * **Deletion Grace Period**: The `deleteAfter` field represents the duration (in hours) after
+	// which an archived task is automatically deleted. Archived tasks can be unarchived during this
+	// period, protecting users from prematurely deleting task resources.
+	// * **Auto-Archive After Inactivity**: The `archiveAfter` field represents the duration (in hours)
+	// of inactivity after which an active task is automatically archived. This feature helps in keeping
+	// the project organized by archiving active tasks, ensuring that storage resources are freed
+	// optimistically.
+	// Setting either value to `0` will result in disabling of that feature. For example, a project's
+	// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
+	// auto-deleting.
+	//
+	// GET /htc/workspaces/{workspaceId}/task-retention-policy
+	GetTaskRetentionPolicy(ctx context.Context, params GetTaskRetentionPolicyParams) (GetTaskRetentionPolicyRes, error)
+	// GetWorkspaceLimits invokes getWorkspaceLimits operation.
+	//
+	// This endpoint will get the resource limit applied to this workspace.
+	//
+	// GET /htc/workspaces/{workspaceId}/limits
+	GetWorkspaceLimits(ctx context.Context, params GetWorkspaceLimitsParams) (GetWorkspaceLimitsRes, error)
+	// PutTaskRetentionPolicy invokes putTaskRetentionPolicy operation.
+	//
+	// This endpoint enables Workspace administrators to define or update the task retention policy for a
+	// specific workspace. The task retention policy includes two key aspects:
+	// * **Deletion Grace Period**: The `deleteAfter` field allows administrators to set the duration (in
+	// hours) after which an archived task is automatically deleted. This control allows for flexibility
+	// in managing the lifecycle of tasks, ensuring that data is retained for an adequate period before
+	// being permanently deleted. Archived tasks can be unarchived during this period, protecting users
+	// from prematurely deleting task resources
+	// * **Auto-Archive After Inactivity**: The `archiveAfter` field allows administrators to specify the
+	// duration (in hours) of inactivity after which an active task is automatically archived. This
+	// feature helps in keeping the project organized by archiving active tasks, ensuring that storage
+	// resources are freed optimistically.
+	// Setting either value to `0` will result in disabling of that feature. For example, a workspace's
+	// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
+	// auto-deleting. The policy applies to all projects within the workspace that do not have their own
+	// project-level policy defined. If a project within the workspace has its own retention policy
+	// defined, the project-level policy takes precedence over the workspace-level policy.
+	//
+	// PUT /htc/workspaces/{workspaceId}/task-retention-policy
+	PutTaskRetentionPolicy(ctx context.Context, request OptWorkspaceTaskRetentionPolicy, params PutTaskRetentionPolicyParams) (PutTaskRetentionPolicyRes, error)
 }
 
 // Client implements OAS client.
@@ -1947,96 +1947,6 @@ func (c *Client) sendGetJobs(ctx context.Context, params GetJobsParams) (res Get
 	return result, nil
 }
 
-// GetLimits invokes getLimits operation.
-//
-// This endpoint will list all resource limitations associated with this project.
-// A job running in this project will be subject to all resulting limits as well as any associated
-// with the workspace (see `/htc/workspaces/{workspaceId}/limits`).
-//
-// GET /htc/projects/{projectId}/limits
-func (c *Client) GetLimits(ctx context.Context, params GetLimitsParams) (GetLimitsRes, error) {
-	res, err := c.sendGetLimits(ctx, params)
-	return res, err
-}
-
-func (c *Client) sendGetLimits(ctx context.Context, params GetLimitsParams) (res GetLimitsRes, err error) {
-
-	u := uri.Clone(c.requestURL(ctx))
-	var pathParts [3]string
-	pathParts[0] = "/htc/projects/"
-	{
-		// Encode "projectId" parameter.
-		e := uri.NewPathEncoder(uri.PathEncoderConfig{
-			Param:   "projectId",
-			Style:   uri.PathStyleSimple,
-			Explode: false,
-		})
-		if err := func() error {
-			return e.EncodeValue(conv.StringToString(params.ProjectId))
-		}(); err != nil {
-			return res, errors.Wrap(err, "encode path")
-		}
-		encoded, err := e.Result()
-		if err != nil {
-			return res, errors.Wrap(err, "encode path")
-		}
-		pathParts[1] = encoded
-	}
-	pathParts[2] = "/limits"
-	uri.AddPathParts(u, pathParts[:]...)
-
-	r, err := ht.NewRequest(ctx, "GET", u)
-	if err != nil {
-		return res, errors.Wrap(err, "create request")
-	}
-
-	{
-		type bitset = [1]uint8
-		var satisfied bitset
-		{
-
-			switch err := c.securitySecurityScheme(ctx, "GetLimits", r); {
-			case err == nil: // if NO error
-				satisfied[0] |= 1 << 0
-			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
-				// Skip this security.
-			default:
-				return res, errors.Wrap(err, "security \"SecurityScheme\"")
-			}
-		}
-
-		if ok := func() bool {
-		nextRequirement:
-			for _, requirement := range []bitset{
-				{0b00000001},
-			} {
-				for i, mask := range requirement {
-					if satisfied[i]&mask != mask {
-						continue nextRequirement
-					}
-				}
-				return true
-			}
-			return false
-		}(); !ok {
-			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
-		}
-	}
-
-	resp, err := c.cfg.Client.Do(r)
-	if err != nil {
-		return res, errors.Wrap(err, "do request")
-	}
-	defer resp.Body.Close()
-
-	result, err := decodeGetLimitsResponse(resp)
-	if err != nil {
-		return res, errors.Wrap(err, "decode response")
-	}
-
-	return result, nil
-}
-
 // GetLogs invokes getLogs operation.
 //
 // This endpoint will get job logs.
@@ -2398,6 +2308,96 @@ func (c *Client) sendGetProject(ctx context.Context, params GetProjectParams) (r
 	return result, nil
 }
 
+// GetProjectLimits invokes getProjectLimits operation.
+//
+// This endpoint will list all resource limitations associated with this project.
+// A job running in this project will be subject to all resulting limits as well as any associated
+// with the workspace (see `/htc/workspaces/{workspaceId}/limits`).
+//
+// GET /htc/projects/{projectId}/limits
+func (c *Client) GetProjectLimits(ctx context.Context, params GetProjectLimitsParams) (GetProjectLimitsRes, error) {
+	res, err := c.sendGetProjectLimits(ctx, params)
+	return res, err
+}
+
+func (c *Client) sendGetProjectLimits(ctx context.Context, params GetProjectLimitsParams) (res GetProjectLimitsRes, err error) {
+
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [3]string
+	pathParts[0] = "/htc/projects/"
+	{
+		// Encode "projectId" parameter.
+		e := uri.NewPathEncoder(uri.PathEncoderConfig{
+			Param:   "projectId",
+			Style:   uri.PathStyleSimple,
+			Explode: false,
+		})
+		if err := func() error {
+			return e.EncodeValue(conv.StringToString(params.ProjectId))
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		encoded, err := e.Result()
+		if err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		pathParts[1] = encoded
+	}
+	pathParts[2] = "/limits"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	r, err := ht.NewRequest(ctx, "GET", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+
+			switch err := c.securitySecurityScheme(ctx, "GetProjectLimits", r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 0
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"SecurityScheme\"")
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
+		}
+	}
+
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	result, err := decodeGetProjectLimitsResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
 // GetProjects invokes getProjects operation.
 //
 // This endpoint will get all projects.
@@ -2605,6 +2605,106 @@ func (c *Client) sendGetRegistryToken(ctx context.Context, params GetRegistryTok
 	defer resp.Body.Close()
 
 	result, err := decodeGetRegistryTokenResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// GetTaskRetentionPolicy invokes getTaskRetentionPolicy operation.
+//
+// This endpoint is used to retrieve the current task retention policy of a specific Workspace. The
+// task retention policy is necessary in managing the lifecycle of tasks within a Workspace. The task
+// retention policy includes two key aspects:
+// * **Deletion Grace Period**: The `deleteAfter` field represents the duration (in hours) after
+// which an archived task is automatically deleted. Archived tasks can be unarchived during this
+// period, protecting users from prematurely deleting task resources.
+// * **Auto-Archive After Inactivity**: The `archiveAfter` field represents the duration (in hours)
+// of inactivity after which an active task is automatically archived. This feature helps in keeping
+// the project organized by archiving active tasks, ensuring that storage resources are freed
+// optimistically.
+// Setting either value to `0` will result in disabling of that feature. For example, a project's
+// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
+// auto-deleting.
+//
+// GET /htc/workspaces/{workspaceId}/task-retention-policy
+func (c *Client) GetTaskRetentionPolicy(ctx context.Context, params GetTaskRetentionPolicyParams) (GetTaskRetentionPolicyRes, error) {
+	res, err := c.sendGetTaskRetentionPolicy(ctx, params)
+	return res, err
+}
+
+func (c *Client) sendGetTaskRetentionPolicy(ctx context.Context, params GetTaskRetentionPolicyParams) (res GetTaskRetentionPolicyRes, err error) {
+
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [3]string
+	pathParts[0] = "/htc/workspaces/"
+	{
+		// Encode "workspaceId" parameter.
+		e := uri.NewPathEncoder(uri.PathEncoderConfig{
+			Param:   "workspaceId",
+			Style:   uri.PathStyleSimple,
+			Explode: false,
+		})
+		if err := func() error {
+			return e.EncodeValue(conv.StringToString(params.WorkspaceId))
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		encoded, err := e.Result()
+		if err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		pathParts[1] = encoded
+	}
+	pathParts[2] = "/task-retention-policy"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	r, err := ht.NewRequest(ctx, "GET", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+
+			switch err := c.securitySecurityScheme(ctx, "GetTaskRetentionPolicy", r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 0
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"SecurityScheme\"")
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
+		}
+	}
+
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	result, err := decodeGetTaskRetentionPolicyResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}
@@ -2922,6 +3022,94 @@ func (c *Client) sendGetToken(ctx context.Context, params GetTokenParams) (res G
 	defer resp.Body.Close()
 
 	result, err := decodeGetTokenResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// GetWorkspaceLimits invokes getWorkspaceLimits operation.
+//
+// This endpoint will get the resource limit applied to this workspace.
+//
+// GET /htc/workspaces/{workspaceId}/limits
+func (c *Client) GetWorkspaceLimits(ctx context.Context, params GetWorkspaceLimitsParams) (GetWorkspaceLimitsRes, error) {
+	res, err := c.sendGetWorkspaceLimits(ctx, params)
+	return res, err
+}
+
+func (c *Client) sendGetWorkspaceLimits(ctx context.Context, params GetWorkspaceLimitsParams) (res GetWorkspaceLimitsRes, err error) {
+
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [3]string
+	pathParts[0] = "/htc/workspaces/"
+	{
+		// Encode "workspaceId" parameter.
+		e := uri.NewPathEncoder(uri.PathEncoderConfig{
+			Param:   "workspaceId",
+			Style:   uri.PathStyleSimple,
+			Explode: false,
+		})
+		if err := func() error {
+			return e.EncodeValue(conv.StringToString(params.WorkspaceId))
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		encoded, err := e.Result()
+		if err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		pathParts[1] = encoded
+	}
+	pathParts[2] = "/limits"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	r, err := ht.NewRequest(ctx, "GET", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+
+			switch err := c.securitySecurityScheme(ctx, "GetWorkspaceLimits", r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 0
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"SecurityScheme\"")
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
+		}
+	}
+
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	result, err := decodeGetWorkspaceLimitsResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}
@@ -5981,300 +6169,6 @@ func (c *Client) sendHtcWorkspacesWorkspaceIdDimensionsGet(ctx context.Context, 
 	return result, nil
 }
 
-// HtcWorkspacesWorkspaceIdLimitsGet invokes GET /htc/workspaces/{workspaceId}/limits operation.
-//
-// This endpoint will get the resource limit applied to this workspace.
-//
-// GET /htc/workspaces/{workspaceId}/limits
-func (c *Client) HtcWorkspacesWorkspaceIdLimitsGet(ctx context.Context, params HtcWorkspacesWorkspaceIdLimitsGetParams) (HtcWorkspacesWorkspaceIdLimitsGetRes, error) {
-	res, err := c.sendHtcWorkspacesWorkspaceIdLimitsGet(ctx, params)
-	return res, err
-}
-
-func (c *Client) sendHtcWorkspacesWorkspaceIdLimitsGet(ctx context.Context, params HtcWorkspacesWorkspaceIdLimitsGetParams) (res HtcWorkspacesWorkspaceIdLimitsGetRes, err error) {
-
-	u := uri.Clone(c.requestURL(ctx))
-	var pathParts [3]string
-	pathParts[0] = "/htc/workspaces/"
-	{
-		// Encode "workspaceId" parameter.
-		e := uri.NewPathEncoder(uri.PathEncoderConfig{
-			Param:   "workspaceId",
-			Style:   uri.PathStyleSimple,
-			Explode: false,
-		})
-		if err := func() error {
-			return e.EncodeValue(conv.StringToString(params.WorkspaceId))
-		}(); err != nil {
-			return res, errors.Wrap(err, "encode path")
-		}
-		encoded, err := e.Result()
-		if err != nil {
-			return res, errors.Wrap(err, "encode path")
-		}
-		pathParts[1] = encoded
-	}
-	pathParts[2] = "/limits"
-	uri.AddPathParts(u, pathParts[:]...)
-
-	r, err := ht.NewRequest(ctx, "GET", u)
-	if err != nil {
-		return res, errors.Wrap(err, "create request")
-	}
-
-	{
-		type bitset = [1]uint8
-		var satisfied bitset
-		{
-
-			switch err := c.securitySecurityScheme(ctx, "HtcWorkspacesWorkspaceIdLimitsGet", r); {
-			case err == nil: // if NO error
-				satisfied[0] |= 1 << 0
-			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
-				// Skip this security.
-			default:
-				return res, errors.Wrap(err, "security \"SecurityScheme\"")
-			}
-		}
-
-		if ok := func() bool {
-		nextRequirement:
-			for _, requirement := range []bitset{
-				{0b00000001},
-			} {
-				for i, mask := range requirement {
-					if satisfied[i]&mask != mask {
-						continue nextRequirement
-					}
-				}
-				return true
-			}
-			return false
-		}(); !ok {
-			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
-		}
-	}
-
-	resp, err := c.cfg.Client.Do(r)
-	if err != nil {
-		return res, errors.Wrap(err, "do request")
-	}
-	defer resp.Body.Close()
-
-	result, err := decodeHtcWorkspacesWorkspaceIdLimitsGetResponse(resp)
-	if err != nil {
-		return res, errors.Wrap(err, "decode response")
-	}
-
-	return result, nil
-}
-
-// HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet invokes GET /htc/workspaces/{workspaceId}/task-retention-policy operation.
-//
-// This endpoint is used to retrieve the current task retention policy of a specific Workspace. The
-// task retention policy is necessary in managing the lifecycle of tasks within a Workspace. The task
-// retention policy includes two key aspects:
-// * **Deletion Grace Period**: The `deleteAfter` field represents the duration (in hours) after
-// which an archived task is automatically deleted. Archived tasks can be unarchived during this
-// period, protecting users from prematurely deleting task resources.
-// * **Auto-Archive After Inactivity**: The `archiveAfter` field represents the duration (in hours)
-// of inactivity after which an active task is automatically archived. This feature helps in keeping
-// the project organized by archiving active tasks, ensuring that storage resources are freed
-// optimistically.
-// Setting either value to `0` will result in disabling of that feature. For example, a project's
-// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
-// auto-deleting.
-//
-// GET /htc/workspaces/{workspaceId}/task-retention-policy
-func (c *Client) HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet(ctx context.Context, params HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams) (HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes, error) {
-	res, err := c.sendHtcWorkspacesWorkspaceIdTaskRetentionPolicyGet(ctx, params)
-	return res, err
-}
-
-func (c *Client) sendHtcWorkspacesWorkspaceIdTaskRetentionPolicyGet(ctx context.Context, params HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams) (res HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes, err error) {
-
-	u := uri.Clone(c.requestURL(ctx))
-	var pathParts [3]string
-	pathParts[0] = "/htc/workspaces/"
-	{
-		// Encode "workspaceId" parameter.
-		e := uri.NewPathEncoder(uri.PathEncoderConfig{
-			Param:   "workspaceId",
-			Style:   uri.PathStyleSimple,
-			Explode: false,
-		})
-		if err := func() error {
-			return e.EncodeValue(conv.StringToString(params.WorkspaceId))
-		}(); err != nil {
-			return res, errors.Wrap(err, "encode path")
-		}
-		encoded, err := e.Result()
-		if err != nil {
-			return res, errors.Wrap(err, "encode path")
-		}
-		pathParts[1] = encoded
-	}
-	pathParts[2] = "/task-retention-policy"
-	uri.AddPathParts(u, pathParts[:]...)
-
-	r, err := ht.NewRequest(ctx, "GET", u)
-	if err != nil {
-		return res, errors.Wrap(err, "create request")
-	}
-
-	{
-		type bitset = [1]uint8
-		var satisfied bitset
-		{
-
-			switch err := c.securitySecurityScheme(ctx, "HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet", r); {
-			case err == nil: // if NO error
-				satisfied[0] |= 1 << 0
-			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
-				// Skip this security.
-			default:
-				return res, errors.Wrap(err, "security \"SecurityScheme\"")
-			}
-		}
-
-		if ok := func() bool {
-		nextRequirement:
-			for _, requirement := range []bitset{
-				{0b00000001},
-			} {
-				for i, mask := range requirement {
-					if satisfied[i]&mask != mask {
-						continue nextRequirement
-					}
-				}
-				return true
-			}
-			return false
-		}(); !ok {
-			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
-		}
-	}
-
-	resp, err := c.cfg.Client.Do(r)
-	if err != nil {
-		return res, errors.Wrap(err, "do request")
-	}
-	defer resp.Body.Close()
-
-	result, err := decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetResponse(resp)
-	if err != nil {
-		return res, errors.Wrap(err, "decode response")
-	}
-
-	return result, nil
-}
-
-// HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut invokes PUT /htc/workspaces/{workspaceId}/task-retention-policy operation.
-//
-// This endpoint enables Workspace administrators to define or update the task retention policy for a
-// specific workspace. The task retention policy includes two key aspects:
-// * **Deletion Grace Period**: The `deleteAfter` field allows administrators to set the duration (in
-// hours) after which an archived task is automatically deleted. This control allows for flexibility
-// in managing the lifecycle of tasks, ensuring that data is retained for an adequate period before
-// being permanently deleted. Archived tasks can be unarchived during this period, protecting users
-// from prematurely deleting task resources
-// * **Auto-Archive After Inactivity**: The `archiveAfter` field allows administrators to specify the
-// duration (in hours) of inactivity after which an active task is automatically archived. This
-// feature helps in keeping the project organized by archiving active tasks, ensuring that storage
-// resources are freed optimistically.
-// Setting either value to `0` will result in disabling of that feature. For example, a workspace's
-// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
-// auto-deleting. The policy applies to all projects within the workspace that do not have their own
-// project-level policy defined. If a project within the workspace has its own retention policy
-// defined, the project-level policy takes precedence over the workspace-level policy.
-//
-// PUT /htc/workspaces/{workspaceId}/task-retention-policy
-func (c *Client) HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut(ctx context.Context, request OptWorkspaceTaskRetentionPolicy, params HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams) (HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes, error) {
-	res, err := c.sendHtcWorkspacesWorkspaceIdTaskRetentionPolicyPut(ctx, request, params)
-	return res, err
-}
-
-func (c *Client) sendHtcWorkspacesWorkspaceIdTaskRetentionPolicyPut(ctx context.Context, request OptWorkspaceTaskRetentionPolicy, params HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams) (res HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes, err error) {
-
-	u := uri.Clone(c.requestURL(ctx))
-	var pathParts [3]string
-	pathParts[0] = "/htc/workspaces/"
-	{
-		// Encode "workspaceId" parameter.
-		e := uri.NewPathEncoder(uri.PathEncoderConfig{
-			Param:   "workspaceId",
-			Style:   uri.PathStyleSimple,
-			Explode: false,
-		})
-		if err := func() error {
-			return e.EncodeValue(conv.StringToString(params.WorkspaceId))
-		}(); err != nil {
-			return res, errors.Wrap(err, "encode path")
-		}
-		encoded, err := e.Result()
-		if err != nil {
-			return res, errors.Wrap(err, "encode path")
-		}
-		pathParts[1] = encoded
-	}
-	pathParts[2] = "/task-retention-policy"
-	uri.AddPathParts(u, pathParts[:]...)
-
-	r, err := ht.NewRequest(ctx, "PUT", u)
-	if err != nil {
-		return res, errors.Wrap(err, "create request")
-	}
-	if err := encodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRequest(request, r); err != nil {
-		return res, errors.Wrap(err, "encode request")
-	}
-
-	{
-		type bitset = [1]uint8
-		var satisfied bitset
-		{
-
-			switch err := c.securitySecurityScheme(ctx, "HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut", r); {
-			case err == nil: // if NO error
-				satisfied[0] |= 1 << 0
-			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
-				// Skip this security.
-			default:
-				return res, errors.Wrap(err, "security \"SecurityScheme\"")
-			}
-		}
-
-		if ok := func() bool {
-		nextRequirement:
-			for _, requirement := range []bitset{
-				{0b00000001},
-			} {
-				for i, mask := range requirement {
-					if satisfied[i]&mask != mask {
-						continue nextRequirement
-					}
-				}
-				return true
-			}
-			return false
-		}(); !ok {
-			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
-		}
-	}
-
-	resp, err := c.cfg.Client.Do(r)
-	if err != nil {
-		return res, errors.Wrap(err, "do request")
-	}
-	defer resp.Body.Close()
-
-	result, err := decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutResponse(resp)
-	if err != nil {
-		return res, errors.Wrap(err, "decode response")
-	}
-
-	return result, nil
-}
-
 // OAuth2TokenPost invokes POST /oauth2/token operation.
 //
 // This endpoint will get an OAuth access token.
@@ -6304,6 +6198,112 @@ func (c *Client) sendOAuth2TokenPost(ctx context.Context) (res OAuth2TokenPostRe
 	defer resp.Body.Close()
 
 	result, err := decodeOAuth2TokenPostResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// PutTaskRetentionPolicy invokes putTaskRetentionPolicy operation.
+//
+// This endpoint enables Workspace administrators to define or update the task retention policy for a
+// specific workspace. The task retention policy includes two key aspects:
+// * **Deletion Grace Period**: The `deleteAfter` field allows administrators to set the duration (in
+// hours) after which an archived task is automatically deleted. This control allows for flexibility
+// in managing the lifecycle of tasks, ensuring that data is retained for an adequate period before
+// being permanently deleted. Archived tasks can be unarchived during this period, protecting users
+// from prematurely deleting task resources
+// * **Auto-Archive After Inactivity**: The `archiveAfter` field allows administrators to specify the
+// duration (in hours) of inactivity after which an active task is automatically archived. This
+// feature helps in keeping the project organized by archiving active tasks, ensuring that storage
+// resources are freed optimistically.
+// Setting either value to `0` will result in disabling of that feature. For example, a workspace's
+// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
+// auto-deleting. The policy applies to all projects within the workspace that do not have their own
+// project-level policy defined. If a project within the workspace has its own retention policy
+// defined, the project-level policy takes precedence over the workspace-level policy.
+//
+// PUT /htc/workspaces/{workspaceId}/task-retention-policy
+func (c *Client) PutTaskRetentionPolicy(ctx context.Context, request OptWorkspaceTaskRetentionPolicy, params PutTaskRetentionPolicyParams) (PutTaskRetentionPolicyRes, error) {
+	res, err := c.sendPutTaskRetentionPolicy(ctx, request, params)
+	return res, err
+}
+
+func (c *Client) sendPutTaskRetentionPolicy(ctx context.Context, request OptWorkspaceTaskRetentionPolicy, params PutTaskRetentionPolicyParams) (res PutTaskRetentionPolicyRes, err error) {
+
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [3]string
+	pathParts[0] = "/htc/workspaces/"
+	{
+		// Encode "workspaceId" parameter.
+		e := uri.NewPathEncoder(uri.PathEncoderConfig{
+			Param:   "workspaceId",
+			Style:   uri.PathStyleSimple,
+			Explode: false,
+		})
+		if err := func() error {
+			return e.EncodeValue(conv.StringToString(params.WorkspaceId))
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		encoded, err := e.Result()
+		if err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		pathParts[1] = encoded
+	}
+	pathParts[2] = "/task-retention-policy"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	r, err := ht.NewRequest(ctx, "PUT", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodePutTaskRetentionPolicyRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+
+			switch err := c.securitySecurityScheme(ctx, "PutTaskRetentionPolicy", r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 0
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"SecurityScheme\"")
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
+		}
+	}
+
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	result, err := decodePutTaskRetentionPolicyResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/v2/api/_oas/oas_handlers_gen.go
+++ b/v2/api/_oas/oas_handlers_gen.go
@@ -1581,131 +1581,6 @@ func (s *Server) handleGetJobsRequest(args [2]string, argsEscaped bool, w http.R
 	}
 }
 
-// handleGetLimitsRequest handles getLimits operation.
-//
-// This endpoint will list all resource limitations associated with this project.
-// A job running in this project will be subject to all resulting limits as well as any associated
-// with the workspace (see `/htc/workspaces/{workspaceId}/limits`).
-//
-// GET /htc/projects/{projectId}/limits
-func (s *Server) handleGetLimitsRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	var (
-		err          error
-		opErrContext = ogenerrors.OperationContext{
-			Name: "GetLimits",
-			ID:   "getLimits",
-		}
-	)
-	{
-		type bitset = [1]uint8
-		var satisfied bitset
-		{
-			sctx, ok, err := s.securitySecurityScheme(ctx, "GetLimits", r)
-			if err != nil {
-				err = &ogenerrors.SecurityError{
-					OperationContext: opErrContext,
-					Security:         "SecurityScheme",
-					Err:              err,
-				}
-				defer recordError("Security:SecurityScheme", err)
-				s.cfg.ErrorHandler(ctx, w, r, err)
-				return
-			}
-			if ok {
-				satisfied[0] |= 1 << 0
-				ctx = sctx
-			}
-		}
-
-		if ok := func() bool {
-		nextRequirement:
-			for _, requirement := range []bitset{
-				{0b00000001},
-			} {
-				for i, mask := range requirement {
-					if satisfied[i]&mask != mask {
-						continue nextRequirement
-					}
-				}
-				return true
-			}
-			return false
-		}(); !ok {
-			err = &ogenerrors.SecurityError{
-				OperationContext: opErrContext,
-				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
-			}
-			defer recordError("Security", err)
-			s.cfg.ErrorHandler(ctx, w, r, err)
-			return
-		}
-	}
-	params, err := decodeGetLimitsParams(args, argsEscaped, r)
-	if err != nil {
-		err = &ogenerrors.DecodeParamsError{
-			OperationContext: opErrContext,
-			Err:              err,
-		}
-		defer recordError("DecodeParams", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-
-	var response GetLimitsRes
-	if m := s.cfg.Middleware; m != nil {
-		mreq := middleware.Request{
-			Context:          ctx,
-			OperationName:    "GetLimits",
-			OperationSummary: "Get Project Limits",
-			OperationID:      "getLimits",
-			Body:             nil,
-			Params: middleware.Parameters{
-				{
-					Name: "projectId",
-					In:   "path",
-				}: params.ProjectId,
-			},
-			Raw: r,
-		}
-
-		type (
-			Request  = struct{}
-			Params   = GetLimitsParams
-			Response = GetLimitsRes
-		)
-		response, err = middleware.HookMiddleware[
-			Request,
-			Params,
-			Response,
-		](
-			m,
-			mreq,
-			unpackGetLimitsParams,
-			func(ctx context.Context, request Request, params Params) (response Response, err error) {
-				response, err = s.h.GetLimits(ctx, params)
-				return response, err
-			},
-		)
-	} else {
-		response, err = s.h.GetLimits(ctx, params)
-	}
-	if err != nil {
-		defer recordError("Internal", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-
-	if err := encodeGetLimitsResponse(response, w); err != nil {
-		defer recordError("EncodeResponse", err)
-		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
-			s.cfg.ErrorHandler(ctx, w, r, err)
-		}
-		return
-	}
-}
-
 // handleGetLogsRequest handles getLogs operation.
 //
 // This endpoint will get job logs.
@@ -2095,6 +1970,131 @@ func (s *Server) handleGetProjectRequest(args [1]string, argsEscaped bool, w htt
 	}
 }
 
+// handleGetProjectLimitsRequest handles getProjectLimits operation.
+//
+// This endpoint will list all resource limitations associated with this project.
+// A job running in this project will be subject to all resulting limits as well as any associated
+// with the workspace (see `/htc/workspaces/{workspaceId}/limits`).
+//
+// GET /htc/projects/{projectId}/limits
+func (s *Server) handleGetProjectLimitsRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var (
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "GetProjectLimits",
+			ID:   "getProjectLimits",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securitySecurityScheme(ctx, "GetProjectLimits", r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "SecurityScheme",
+					Err:              err,
+				}
+				defer recordError("Security:SecurityScheme", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+	params, err := decodeGetProjectLimitsParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var response GetProjectLimitsRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "GetProjectLimits",
+			OperationSummary: "Get Project Limits",
+			OperationID:      "getProjectLimits",
+			Body:             nil,
+			Params: middleware.Parameters{
+				{
+					Name: "projectId",
+					In:   "path",
+				}: params.ProjectId,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = GetProjectLimitsParams
+			Response = GetProjectLimitsRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackGetProjectLimitsParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.GetProjectLimits(ctx, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.GetProjectLimits(ctx, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeGetProjectLimitsResponse(response, w); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handleGetProjectsRequest handles getProjects operation.
 //
 // This endpoint will get all projects.
@@ -2344,6 +2344,141 @@ func (s *Server) handleGetRegistryTokenRequest(args [1]string, argsEscaped bool,
 	}
 
 	if err := encodeGetRegistryTokenResponse(response, w); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleGetTaskRetentionPolicyRequest handles getTaskRetentionPolicy operation.
+//
+// This endpoint is used to retrieve the current task retention policy of a specific Workspace. The
+// task retention policy is necessary in managing the lifecycle of tasks within a Workspace. The task
+// retention policy includes two key aspects:
+// * **Deletion Grace Period**: The `deleteAfter` field represents the duration (in hours) after
+// which an archived task is automatically deleted. Archived tasks can be unarchived during this
+// period, protecting users from prematurely deleting task resources.
+// * **Auto-Archive After Inactivity**: The `archiveAfter` field represents the duration (in hours)
+// of inactivity after which an active task is automatically archived. This feature helps in keeping
+// the project organized by archiving active tasks, ensuring that storage resources are freed
+// optimistically.
+// Setting either value to `0` will result in disabling of that feature. For example, a project's
+// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
+// auto-deleting.
+//
+// GET /htc/workspaces/{workspaceId}/task-retention-policy
+func (s *Server) handleGetTaskRetentionPolicyRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var (
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "GetTaskRetentionPolicy",
+			ID:   "getTaskRetentionPolicy",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securitySecurityScheme(ctx, "GetTaskRetentionPolicy", r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "SecurityScheme",
+					Err:              err,
+				}
+				defer recordError("Security:SecurityScheme", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+	params, err := decodeGetTaskRetentionPolicyParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var response GetTaskRetentionPolicyRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "GetTaskRetentionPolicy",
+			OperationSummary: "Get Workspace Task Retention Policy",
+			OperationID:      "getTaskRetentionPolicy",
+			Body:             nil,
+			Params: middleware.Parameters{
+				{
+					Name: "workspaceId",
+					In:   "path",
+				}: params.WorkspaceId,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = GetTaskRetentionPolicyParams
+			Response = GetTaskRetentionPolicyRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackGetTaskRetentionPolicyParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.GetTaskRetentionPolicy(ctx, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.GetTaskRetentionPolicy(ctx, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeGetTaskRetentionPolicyResponse(response, w); err != nil {
 		defer recordError("EncodeResponse", err)
 		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
 			s.cfg.ErrorHandler(ctx, w, r, err)
@@ -2725,6 +2860,129 @@ func (s *Server) handleGetTokenRequest(args [0]string, argsEscaped bool, w http.
 	}
 
 	if err := encodeGetTokenResponse(response, w); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleGetWorkspaceLimitsRequest handles getWorkspaceLimits operation.
+//
+// This endpoint will get the resource limit applied to this workspace.
+//
+// GET /htc/workspaces/{workspaceId}/limits
+func (s *Server) handleGetWorkspaceLimitsRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var (
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "GetWorkspaceLimits",
+			ID:   "getWorkspaceLimits",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securitySecurityScheme(ctx, "GetWorkspaceLimits", r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "SecurityScheme",
+					Err:              err,
+				}
+				defer recordError("Security:SecurityScheme", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+	params, err := decodeGetWorkspaceLimitsParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var response GetWorkspaceLimitsRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "GetWorkspaceLimits",
+			OperationSummary: "Get Workspace Limit",
+			OperationID:      "getWorkspaceLimits",
+			Body:             nil,
+			Params: middleware.Parameters{
+				{
+					Name: "workspaceId",
+					In:   "path",
+				}: params.WorkspaceId,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = GetWorkspaceLimitsParams
+			Response = GetWorkspaceLimitsRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackGetWorkspaceLimitsParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.GetWorkspaceLimits(ctx, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.GetWorkspaceLimits(ctx, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeGetWorkspaceLimitsResponse(response, w); err != nil {
 		defer recordError("EncodeResponse", err)
 		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
 			s.cfg.ErrorHandler(ctx, w, r, err)
@@ -6542,417 +6800,6 @@ func (s *Server) handleHtcWorkspacesWorkspaceIdDimensionsGetRequest(args [1]stri
 	}
 }
 
-// handleHtcWorkspacesWorkspaceIdLimitsGetRequest handles GET /htc/workspaces/{workspaceId}/limits operation.
-//
-// This endpoint will get the resource limit applied to this workspace.
-//
-// GET /htc/workspaces/{workspaceId}/limits
-func (s *Server) handleHtcWorkspacesWorkspaceIdLimitsGetRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	var (
-		err          error
-		opErrContext = ogenerrors.OperationContext{
-			Name: "HtcWorkspacesWorkspaceIdLimitsGet",
-			ID:   "",
-		}
-	)
-	{
-		type bitset = [1]uint8
-		var satisfied bitset
-		{
-			sctx, ok, err := s.securitySecurityScheme(ctx, "HtcWorkspacesWorkspaceIdLimitsGet", r)
-			if err != nil {
-				err = &ogenerrors.SecurityError{
-					OperationContext: opErrContext,
-					Security:         "SecurityScheme",
-					Err:              err,
-				}
-				defer recordError("Security:SecurityScheme", err)
-				s.cfg.ErrorHandler(ctx, w, r, err)
-				return
-			}
-			if ok {
-				satisfied[0] |= 1 << 0
-				ctx = sctx
-			}
-		}
-
-		if ok := func() bool {
-		nextRequirement:
-			for _, requirement := range []bitset{
-				{0b00000001},
-			} {
-				for i, mask := range requirement {
-					if satisfied[i]&mask != mask {
-						continue nextRequirement
-					}
-				}
-				return true
-			}
-			return false
-		}(); !ok {
-			err = &ogenerrors.SecurityError{
-				OperationContext: opErrContext,
-				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
-			}
-			defer recordError("Security", err)
-			s.cfg.ErrorHandler(ctx, w, r, err)
-			return
-		}
-	}
-	params, err := decodeHtcWorkspacesWorkspaceIdLimitsGetParams(args, argsEscaped, r)
-	if err != nil {
-		err = &ogenerrors.DecodeParamsError{
-			OperationContext: opErrContext,
-			Err:              err,
-		}
-		defer recordError("DecodeParams", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-
-	var response HtcWorkspacesWorkspaceIdLimitsGetRes
-	if m := s.cfg.Middleware; m != nil {
-		mreq := middleware.Request{
-			Context:          ctx,
-			OperationName:    "HtcWorkspacesWorkspaceIdLimitsGet",
-			OperationSummary: "Get Workspace Limit",
-			OperationID:      "",
-			Body:             nil,
-			Params: middleware.Parameters{
-				{
-					Name: "workspaceId",
-					In:   "path",
-				}: params.WorkspaceId,
-			},
-			Raw: r,
-		}
-
-		type (
-			Request  = struct{}
-			Params   = HtcWorkspacesWorkspaceIdLimitsGetParams
-			Response = HtcWorkspacesWorkspaceIdLimitsGetRes
-		)
-		response, err = middleware.HookMiddleware[
-			Request,
-			Params,
-			Response,
-		](
-			m,
-			mreq,
-			unpackHtcWorkspacesWorkspaceIdLimitsGetParams,
-			func(ctx context.Context, request Request, params Params) (response Response, err error) {
-				response, err = s.h.HtcWorkspacesWorkspaceIdLimitsGet(ctx, params)
-				return response, err
-			},
-		)
-	} else {
-		response, err = s.h.HtcWorkspacesWorkspaceIdLimitsGet(ctx, params)
-	}
-	if err != nil {
-		defer recordError("Internal", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-
-	if err := encodeHtcWorkspacesWorkspaceIdLimitsGetResponse(response, w); err != nil {
-		defer recordError("EncodeResponse", err)
-		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
-			s.cfg.ErrorHandler(ctx, w, r, err)
-		}
-		return
-	}
-}
-
-// handleHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRequest handles GET /htc/workspaces/{workspaceId}/task-retention-policy operation.
-//
-// This endpoint is used to retrieve the current task retention policy of a specific Workspace. The
-// task retention policy is necessary in managing the lifecycle of tasks within a Workspace. The task
-// retention policy includes two key aspects:
-// * **Deletion Grace Period**: The `deleteAfter` field represents the duration (in hours) after
-// which an archived task is automatically deleted. Archived tasks can be unarchived during this
-// period, protecting users from prematurely deleting task resources.
-// * **Auto-Archive After Inactivity**: The `archiveAfter` field represents the duration (in hours)
-// of inactivity after which an active task is automatically archived. This feature helps in keeping
-// the project organized by archiving active tasks, ensuring that storage resources are freed
-// optimistically.
-// Setting either value to `0` will result in disabling of that feature. For example, a project's
-// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
-// auto-deleting.
-//
-// GET /htc/workspaces/{workspaceId}/task-retention-policy
-func (s *Server) handleHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	var (
-		err          error
-		opErrContext = ogenerrors.OperationContext{
-			Name: "HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet",
-			ID:   "",
-		}
-	)
-	{
-		type bitset = [1]uint8
-		var satisfied bitset
-		{
-			sctx, ok, err := s.securitySecurityScheme(ctx, "HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet", r)
-			if err != nil {
-				err = &ogenerrors.SecurityError{
-					OperationContext: opErrContext,
-					Security:         "SecurityScheme",
-					Err:              err,
-				}
-				defer recordError("Security:SecurityScheme", err)
-				s.cfg.ErrorHandler(ctx, w, r, err)
-				return
-			}
-			if ok {
-				satisfied[0] |= 1 << 0
-				ctx = sctx
-			}
-		}
-
-		if ok := func() bool {
-		nextRequirement:
-			for _, requirement := range []bitset{
-				{0b00000001},
-			} {
-				for i, mask := range requirement {
-					if satisfied[i]&mask != mask {
-						continue nextRequirement
-					}
-				}
-				return true
-			}
-			return false
-		}(); !ok {
-			err = &ogenerrors.SecurityError{
-				OperationContext: opErrContext,
-				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
-			}
-			defer recordError("Security", err)
-			s.cfg.ErrorHandler(ctx, w, r, err)
-			return
-		}
-	}
-	params, err := decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams(args, argsEscaped, r)
-	if err != nil {
-		err = &ogenerrors.DecodeParamsError{
-			OperationContext: opErrContext,
-			Err:              err,
-		}
-		defer recordError("DecodeParams", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-
-	var response HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes
-	if m := s.cfg.Middleware; m != nil {
-		mreq := middleware.Request{
-			Context:          ctx,
-			OperationName:    "HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet",
-			OperationSummary: "Get Workspace Task Retention Policy",
-			OperationID:      "",
-			Body:             nil,
-			Params: middleware.Parameters{
-				{
-					Name: "workspaceId",
-					In:   "path",
-				}: params.WorkspaceId,
-			},
-			Raw: r,
-		}
-
-		type (
-			Request  = struct{}
-			Params   = HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams
-			Response = HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes
-		)
-		response, err = middleware.HookMiddleware[
-			Request,
-			Params,
-			Response,
-		](
-			m,
-			mreq,
-			unpackHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams,
-			func(ctx context.Context, request Request, params Params) (response Response, err error) {
-				response, err = s.h.HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet(ctx, params)
-				return response, err
-			},
-		)
-	} else {
-		response, err = s.h.HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet(ctx, params)
-	}
-	if err != nil {
-		defer recordError("Internal", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-
-	if err := encodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetResponse(response, w); err != nil {
-		defer recordError("EncodeResponse", err)
-		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
-			s.cfg.ErrorHandler(ctx, w, r, err)
-		}
-		return
-	}
-}
-
-// handleHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRequest handles PUT /htc/workspaces/{workspaceId}/task-retention-policy operation.
-//
-// This endpoint enables Workspace administrators to define or update the task retention policy for a
-// specific workspace. The task retention policy includes two key aspects:
-// * **Deletion Grace Period**: The `deleteAfter` field allows administrators to set the duration (in
-// hours) after which an archived task is automatically deleted. This control allows for flexibility
-// in managing the lifecycle of tasks, ensuring that data is retained for an adequate period before
-// being permanently deleted. Archived tasks can be unarchived during this period, protecting users
-// from prematurely deleting task resources
-// * **Auto-Archive After Inactivity**: The `archiveAfter` field allows administrators to specify the
-// duration (in hours) of inactivity after which an active task is automatically archived. This
-// feature helps in keeping the project organized by archiving active tasks, ensuring that storage
-// resources are freed optimistically.
-// Setting either value to `0` will result in disabling of that feature. For example, a workspace's
-// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
-// auto-deleting. The policy applies to all projects within the workspace that do not have their own
-// project-level policy defined. If a project within the workspace has its own retention policy
-// defined, the project-level policy takes precedence over the workspace-level policy.
-//
-// PUT /htc/workspaces/{workspaceId}/task-retention-policy
-func (s *Server) handleHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	var (
-		err          error
-		opErrContext = ogenerrors.OperationContext{
-			Name: "HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut",
-			ID:   "",
-		}
-	)
-	{
-		type bitset = [1]uint8
-		var satisfied bitset
-		{
-			sctx, ok, err := s.securitySecurityScheme(ctx, "HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut", r)
-			if err != nil {
-				err = &ogenerrors.SecurityError{
-					OperationContext: opErrContext,
-					Security:         "SecurityScheme",
-					Err:              err,
-				}
-				defer recordError("Security:SecurityScheme", err)
-				s.cfg.ErrorHandler(ctx, w, r, err)
-				return
-			}
-			if ok {
-				satisfied[0] |= 1 << 0
-				ctx = sctx
-			}
-		}
-
-		if ok := func() bool {
-		nextRequirement:
-			for _, requirement := range []bitset{
-				{0b00000001},
-			} {
-				for i, mask := range requirement {
-					if satisfied[i]&mask != mask {
-						continue nextRequirement
-					}
-				}
-				return true
-			}
-			return false
-		}(); !ok {
-			err = &ogenerrors.SecurityError{
-				OperationContext: opErrContext,
-				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
-			}
-			defer recordError("Security", err)
-			s.cfg.ErrorHandler(ctx, w, r, err)
-			return
-		}
-	}
-	params, err := decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams(args, argsEscaped, r)
-	if err != nil {
-		err = &ogenerrors.DecodeParamsError{
-			OperationContext: opErrContext,
-			Err:              err,
-		}
-		defer recordError("DecodeParams", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-	request, close, err := s.decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRequest(r)
-	if err != nil {
-		err = &ogenerrors.DecodeRequestError{
-			OperationContext: opErrContext,
-			Err:              err,
-		}
-		defer recordError("DecodeRequest", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-	defer func() {
-		if err := close(); err != nil {
-			recordError("CloseRequest", err)
-		}
-	}()
-
-	var response HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes
-	if m := s.cfg.Middleware; m != nil {
-		mreq := middleware.Request{
-			Context:          ctx,
-			OperationName:    "HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut",
-			OperationSummary: "Modify Workspace Task Retention Policy",
-			OperationID:      "",
-			Body:             request,
-			Params: middleware.Parameters{
-				{
-					Name: "workspaceId",
-					In:   "path",
-				}: params.WorkspaceId,
-			},
-			Raw: r,
-		}
-
-		type (
-			Request  = OptWorkspaceTaskRetentionPolicy
-			Params   = HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams
-			Response = HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes
-		)
-		response, err = middleware.HookMiddleware[
-			Request,
-			Params,
-			Response,
-		](
-			m,
-			mreq,
-			unpackHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams,
-			func(ctx context.Context, request Request, params Params) (response Response, err error) {
-				response, err = s.h.HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut(ctx, request, params)
-				return response, err
-			},
-		)
-	} else {
-		response, err = s.h.HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut(ctx, request, params)
-	}
-	if err != nil {
-		defer recordError("Internal", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-
-	if err := encodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutResponse(response, w); err != nil {
-		defer recordError("EncodeResponse", err)
-		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
-			s.cfg.ErrorHandler(ctx, w, r, err)
-		}
-		return
-	}
-}
-
 // handleOAuth2TokenPostRequest handles POST /oauth2/token operation.
 //
 // This endpoint will get an OAuth access token.
@@ -7005,6 +6852,159 @@ func (s *Server) handleOAuth2TokenPostRequest(args [0]string, argsEscaped bool, 
 	}
 
 	if err := encodeOAuth2TokenPostResponse(response, w); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handlePutTaskRetentionPolicyRequest handles putTaskRetentionPolicy operation.
+//
+// This endpoint enables Workspace administrators to define or update the task retention policy for a
+// specific workspace. The task retention policy includes two key aspects:
+// * **Deletion Grace Period**: The `deleteAfter` field allows administrators to set the duration (in
+// hours) after which an archived task is automatically deleted. This control allows for flexibility
+// in managing the lifecycle of tasks, ensuring that data is retained for an adequate period before
+// being permanently deleted. Archived tasks can be unarchived during this period, protecting users
+// from prematurely deleting task resources
+// * **Auto-Archive After Inactivity**: The `archiveAfter` field allows administrators to specify the
+// duration (in hours) of inactivity after which an active task is automatically archived. This
+// feature helps in keeping the project organized by archiving active tasks, ensuring that storage
+// resources are freed optimistically.
+// Setting either value to `0` will result in disabling of that feature. For example, a workspace's
+// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
+// auto-deleting. The policy applies to all projects within the workspace that do not have their own
+// project-level policy defined. If a project within the workspace has its own retention policy
+// defined, the project-level policy takes precedence over the workspace-level policy.
+//
+// PUT /htc/workspaces/{workspaceId}/task-retention-policy
+func (s *Server) handlePutTaskRetentionPolicyRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var (
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "PutTaskRetentionPolicy",
+			ID:   "putTaskRetentionPolicy",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securitySecurityScheme(ctx, "PutTaskRetentionPolicy", r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "SecurityScheme",
+					Err:              err,
+				}
+				defer recordError("Security:SecurityScheme", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+	params, err := decodePutTaskRetentionPolicyParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	request, close, err := s.decodePutTaskRetentionPolicyRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response PutTaskRetentionPolicyRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "PutTaskRetentionPolicy",
+			OperationSummary: "Modify Workspace Task Retention Policy",
+			OperationID:      "putTaskRetentionPolicy",
+			Body:             request,
+			Params: middleware.Parameters{
+				{
+					Name: "workspaceId",
+					In:   "path",
+				}: params.WorkspaceId,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = OptWorkspaceTaskRetentionPolicy
+			Params   = PutTaskRetentionPolicyParams
+			Response = PutTaskRetentionPolicyRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackPutTaskRetentionPolicyParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.PutTaskRetentionPolicy(ctx, request, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.PutTaskRetentionPolicy(ctx, request, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodePutTaskRetentionPolicyResponse(response, w); err != nil {
 		defer recordError("EncodeResponse", err)
 		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
 			s.cfg.ErrorHandler(ctx, w, r, err)

--- a/v2/api/_oas/oas_interfaces_gen.go
+++ b/v2/api/_oas/oas_interfaces_gen.go
@@ -21,10 +21,6 @@ type CreateTaskRes interface {
 	createTaskRes()
 }
 
-type GetDimensionsRes interface {
-	getDimensionsRes()
-}
-
 type GetEventsRes interface {
 	getEventsRes()
 }
@@ -57,6 +53,10 @@ type GetMetricsRes interface {
 	getMetricsRes()
 }
 
+type GetProjectDimensionsRes interface {
+	getProjectDimensionsRes()
+}
+
 type GetProjectLimitsRes interface {
 	getProjectLimitsRes()
 }
@@ -87,6 +87,10 @@ type GetTasksRes interface {
 
 type GetTokenRes interface {
 	getTokenRes()
+}
+
+type GetWorkspaceDimensionsRes interface {
+	getWorkspaceDimensionsRes()
 }
 
 type GetWorkspaceLimitsRes interface {
@@ -203,10 +207,6 @@ type HtcStorageGetRes interface {
 
 type HtcStorageRegionRegionGetRes interface {
 	htcStorageRegionRegionGetRes()
-}
-
-type HtcWorkspacesWorkspaceIdDimensionsGetRes interface {
-	htcWorkspacesWorkspaceIdDimensionsGetRes()
 }
 
 type OAuth2TokenPostRes interface {

--- a/v2/api/_oas/oas_interfaces_gen.go
+++ b/v2/api/_oas/oas_interfaces_gen.go
@@ -49,16 +49,16 @@ type GetJobsRes interface {
 	getJobsRes()
 }
 
-type GetLimitsRes interface {
-	getLimitsRes()
-}
-
 type GetLogsRes interface {
 	getLogsRes()
 }
 
 type GetMetricsRes interface {
 	getMetricsRes()
+}
+
+type GetProjectLimitsRes interface {
+	getProjectLimitsRes()
 }
 
 type GetProjectRes interface {
@@ -73,6 +73,10 @@ type GetRegistryTokenRes interface {
 	getRegistryTokenRes()
 }
 
+type GetTaskRetentionPolicyRes interface {
+	getTaskRetentionPolicyRes()
+}
+
 type GetTaskStatsRes interface {
 	getTaskStatsRes()
 }
@@ -83,6 +87,10 @@ type GetTasksRes interface {
 
 type GetTokenRes interface {
 	getTokenRes()
+}
+
+type GetWorkspaceLimitsRes interface {
+	getWorkspaceLimitsRes()
 }
 
 type HtcProjectsProjectIdDimensionsPutRes interface {
@@ -201,20 +209,12 @@ type HtcWorkspacesWorkspaceIdDimensionsGetRes interface {
 	htcWorkspacesWorkspaceIdDimensionsGetRes()
 }
 
-type HtcWorkspacesWorkspaceIdLimitsGetRes interface {
-	htcWorkspacesWorkspaceIdLimitsGetRes()
-}
-
-type HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes interface {
-	htcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes()
-}
-
-type HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes interface {
-	htcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes()
-}
-
 type OAuth2TokenPostRes interface {
 	oAuth2TokenPostRes()
+}
+
+type PutTaskRetentionPolicyRes interface {
+	putTaskRetentionPolicyRes()
 }
 
 type SubmitJobsRes interface {

--- a/v2/api/_oas/oas_json_gen.go
+++ b/v2/api/_oas/oas_json_gen.go
@@ -6420,6 +6420,56 @@ func (s *HTCTokenPayload) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes HTCWorkspaceDimensions as json.
+func (s HTCWorkspaceDimensions) Encode(e *jx.Encoder) {
+	unwrapped := []HTCComputeEnvironment(s)
+
+	e.ArrStart()
+	for _, elem := range unwrapped {
+		elem.Encode(e)
+	}
+	e.ArrEnd()
+}
+
+// Decode decodes HTCWorkspaceDimensions from json.
+func (s *HTCWorkspaceDimensions) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode HTCWorkspaceDimensions to nil")
+	}
+	var unwrapped []HTCComputeEnvironment
+	if err := func() error {
+		unwrapped = make([]HTCComputeEnvironment, 0)
+		if err := d.Arr(func(d *jx.Decoder) error {
+			var elem HTCComputeEnvironment
+			if err := elem.Decode(d); err != nil {
+				return err
+			}
+			unwrapped = append(unwrapped, elem)
+			return nil
+		}); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = HTCWorkspaceDimensions(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s HTCWorkspaceDimensions) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *HTCWorkspaceDimensions) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode implements json.Marshaler.
 func (s *HTCWorkspaceLimit) Encode(e *jx.Encoder) {
 	e.ObjStart()
@@ -7117,56 +7167,6 @@ func (s HtcStorageGetOKApplicationJSON) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *HtcStorageGetOKApplicationJSON) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON as json.
-func (s HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON) Encode(e *jx.Encoder) {
-	unwrapped := []HTCComputeEnvironment(s)
-
-	e.ArrStart()
-	for _, elem := range unwrapped {
-		elem.Encode(e)
-	}
-	e.ArrEnd()
-}
-
-// Decode decodes HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON from json.
-func (s *HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON to nil")
-	}
-	var unwrapped []HTCComputeEnvironment
-	if err := func() error {
-		unwrapped = make([]HTCComputeEnvironment, 0)
-		if err := d.Arr(func(d *jx.Decoder) error {
-			var elem HTCComputeEnvironment
-			if err := elem.Decode(d); err != nil {
-				return err
-			}
-			unwrapped = append(unwrapped, elem)
-			return nil
-		}); err != nil {
-			return err
-		}
-		return nil
-	}(); err != nil {
-		return errors.Wrap(err, "alias")
-	}
-	*s = HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON(unwrapped)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/v2/api/_oas/oas_parameters_gen.go
+++ b/v2/api/_oas/oas_parameters_gen.go
@@ -1610,71 +1610,6 @@ func decodeGetJobsParams(args [2]string, argsEscaped bool, r *http.Request) (par
 	return params, nil
 }
 
-// GetLimitsParams is parameters of getLimits operation.
-type GetLimitsParams struct {
-	ProjectId string
-}
-
-func unpackGetLimitsParams(packed middleware.Parameters) (params GetLimitsParams) {
-	{
-		key := middleware.ParameterKey{
-			Name: "projectId",
-			In:   "path",
-		}
-		params.ProjectId = packed[key].(string)
-	}
-	return params
-}
-
-func decodeGetLimitsParams(args [1]string, argsEscaped bool, r *http.Request) (params GetLimitsParams, _ error) {
-	// Decode path: projectId.
-	if err := func() error {
-		param := args[0]
-		if argsEscaped {
-			unescaped, err := url.PathUnescape(args[0])
-			if err != nil {
-				return errors.Wrap(err, "unescape path")
-			}
-			param = unescaped
-		}
-		if len(param) > 0 {
-			d := uri.NewPathDecoder(uri.PathDecoderConfig{
-				Param:   "projectId",
-				Value:   param,
-				Style:   uri.PathStyleSimple,
-				Explode: false,
-			})
-
-			if err := func() error {
-				val, err := d.DecodeValue()
-				if err != nil {
-					return err
-				}
-
-				c, err := conv.ToString(val)
-				if err != nil {
-					return err
-				}
-
-				params.ProjectId = c
-				return nil
-			}(); err != nil {
-				return err
-			}
-		} else {
-			return validate.ErrFieldRequired
-		}
-		return nil
-	}(); err != nil {
-		return params, &ogenerrors.DecodeParamError{
-			Name: "projectId",
-			In:   "path",
-			Err:  err,
-		}
-	}
-	return params, nil
-}
-
 // GetLogsParams is parameters of getLogs operation.
 type GetLogsParams struct {
 	JobId     string
@@ -2172,6 +2107,71 @@ func decodeGetProjectParams(args [1]string, argsEscaped bool, r *http.Request) (
 	return params, nil
 }
 
+// GetProjectLimitsParams is parameters of getProjectLimits operation.
+type GetProjectLimitsParams struct {
+	ProjectId string
+}
+
+func unpackGetProjectLimitsParams(packed middleware.Parameters) (params GetProjectLimitsParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "projectId",
+			In:   "path",
+		}
+		params.ProjectId = packed[key].(string)
+	}
+	return params
+}
+
+func decodeGetProjectLimitsParams(args [1]string, argsEscaped bool, r *http.Request) (params GetProjectLimitsParams, _ error) {
+	// Decode path: projectId.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "projectId",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.ProjectId = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "projectId",
+			In:   "path",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
 // GetProjectsParams is parameters of getProjects operation.
 type GetProjectsParams struct {
 	OnlyMyProjects OptBool
@@ -2401,6 +2401,71 @@ func decodeGetRegistryTokenParams(args [1]string, argsEscaped bool, r *http.Requ
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "projectId",
+			In:   "path",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
+// GetTaskRetentionPolicyParams is parameters of getTaskRetentionPolicy operation.
+type GetTaskRetentionPolicyParams struct {
+	WorkspaceId string
+}
+
+func unpackGetTaskRetentionPolicyParams(packed middleware.Parameters) (params GetTaskRetentionPolicyParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "workspaceId",
+			In:   "path",
+		}
+		params.WorkspaceId = packed[key].(string)
+	}
+	return params
+}
+
+func decodeGetTaskRetentionPolicyParams(args [1]string, argsEscaped bool, r *http.Request) (params GetTaskRetentionPolicyParams, _ error) {
+	// Decode path: workspaceId.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "workspaceId",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.WorkspaceId = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "workspaceId",
 			In:   "path",
 			Err:  err,
 		}
@@ -2760,6 +2825,71 @@ func decodeGetTokenParams(args [0]string, argsEscaped bool, r *http.Request) (pa
 		return params, &ogenerrors.DecodeParamError{
 			Name: "X-Rescale-Environment",
 			In:   "header",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
+// GetWorkspaceLimitsParams is parameters of getWorkspaceLimits operation.
+type GetWorkspaceLimitsParams struct {
+	WorkspaceId string
+}
+
+func unpackGetWorkspaceLimitsParams(packed middleware.Parameters) (params GetWorkspaceLimitsParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "workspaceId",
+			In:   "path",
+		}
+		params.WorkspaceId = packed[key].(string)
+	}
+	return params
+}
+
+func decodeGetWorkspaceLimitsParams(args [1]string, argsEscaped bool, r *http.Request) (params GetWorkspaceLimitsParams, _ error) {
+	// Decode path: workspaceId.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "workspaceId",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.WorkspaceId = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "workspaceId",
+			In:   "path",
 			Err:  err,
 		}
 	}
@@ -5869,12 +5999,12 @@ func decodeHtcWorkspacesWorkspaceIdDimensionsGetParams(args [1]string, argsEscap
 	return params, nil
 }
 
-// HtcWorkspacesWorkspaceIdLimitsGetParams is parameters of GET /htc/workspaces/{workspaceId}/limits operation.
-type HtcWorkspacesWorkspaceIdLimitsGetParams struct {
+// PutTaskRetentionPolicyParams is parameters of putTaskRetentionPolicy operation.
+type PutTaskRetentionPolicyParams struct {
 	WorkspaceId string
 }
 
-func unpackHtcWorkspacesWorkspaceIdLimitsGetParams(packed middleware.Parameters) (params HtcWorkspacesWorkspaceIdLimitsGetParams) {
+func unpackPutTaskRetentionPolicyParams(packed middleware.Parameters) (params PutTaskRetentionPolicyParams) {
 	{
 		key := middleware.ParameterKey{
 			Name: "workspaceId",
@@ -5885,137 +6015,7 @@ func unpackHtcWorkspacesWorkspaceIdLimitsGetParams(packed middleware.Parameters)
 	return params
 }
 
-func decodeHtcWorkspacesWorkspaceIdLimitsGetParams(args [1]string, argsEscaped bool, r *http.Request) (params HtcWorkspacesWorkspaceIdLimitsGetParams, _ error) {
-	// Decode path: workspaceId.
-	if err := func() error {
-		param := args[0]
-		if argsEscaped {
-			unescaped, err := url.PathUnescape(args[0])
-			if err != nil {
-				return errors.Wrap(err, "unescape path")
-			}
-			param = unescaped
-		}
-		if len(param) > 0 {
-			d := uri.NewPathDecoder(uri.PathDecoderConfig{
-				Param:   "workspaceId",
-				Value:   param,
-				Style:   uri.PathStyleSimple,
-				Explode: false,
-			})
-
-			if err := func() error {
-				val, err := d.DecodeValue()
-				if err != nil {
-					return err
-				}
-
-				c, err := conv.ToString(val)
-				if err != nil {
-					return err
-				}
-
-				params.WorkspaceId = c
-				return nil
-			}(); err != nil {
-				return err
-			}
-		} else {
-			return validate.ErrFieldRequired
-		}
-		return nil
-	}(); err != nil {
-		return params, &ogenerrors.DecodeParamError{
-			Name: "workspaceId",
-			In:   "path",
-			Err:  err,
-		}
-	}
-	return params, nil
-}
-
-// HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams is parameters of GET /htc/workspaces/{workspaceId}/task-retention-policy operation.
-type HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams struct {
-	WorkspaceId string
-}
-
-func unpackHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams(packed middleware.Parameters) (params HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams) {
-	{
-		key := middleware.ParameterKey{
-			Name: "workspaceId",
-			In:   "path",
-		}
-		params.WorkspaceId = packed[key].(string)
-	}
-	return params
-}
-
-func decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams(args [1]string, argsEscaped bool, r *http.Request) (params HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams, _ error) {
-	// Decode path: workspaceId.
-	if err := func() error {
-		param := args[0]
-		if argsEscaped {
-			unescaped, err := url.PathUnescape(args[0])
-			if err != nil {
-				return errors.Wrap(err, "unescape path")
-			}
-			param = unescaped
-		}
-		if len(param) > 0 {
-			d := uri.NewPathDecoder(uri.PathDecoderConfig{
-				Param:   "workspaceId",
-				Value:   param,
-				Style:   uri.PathStyleSimple,
-				Explode: false,
-			})
-
-			if err := func() error {
-				val, err := d.DecodeValue()
-				if err != nil {
-					return err
-				}
-
-				c, err := conv.ToString(val)
-				if err != nil {
-					return err
-				}
-
-				params.WorkspaceId = c
-				return nil
-			}(); err != nil {
-				return err
-			}
-		} else {
-			return validate.ErrFieldRequired
-		}
-		return nil
-	}(); err != nil {
-		return params, &ogenerrors.DecodeParamError{
-			Name: "workspaceId",
-			In:   "path",
-			Err:  err,
-		}
-	}
-	return params, nil
-}
-
-// HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams is parameters of PUT /htc/workspaces/{workspaceId}/task-retention-policy operation.
-type HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams struct {
-	WorkspaceId string
-}
-
-func unpackHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams(packed middleware.Parameters) (params HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams) {
-	{
-		key := middleware.ParameterKey{
-			Name: "workspaceId",
-			In:   "path",
-		}
-		params.WorkspaceId = packed[key].(string)
-	}
-	return params
-}
-
-func decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams(args [1]string, argsEscaped bool, r *http.Request) (params HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams, _ error) {
+func decodePutTaskRetentionPolicyParams(args [1]string, argsEscaped bool, r *http.Request) (params PutTaskRetentionPolicyParams, _ error) {
 	// Decode path: workspaceId.
 	if err := func() error {
 		param := args[0]

--- a/v2/api/_oas/oas_parameters_gen.go
+++ b/v2/api/_oas/oas_parameters_gen.go
@@ -385,71 +385,6 @@ func decodeCreateTaskParams(args [1]string, argsEscaped bool, r *http.Request) (
 	return params, nil
 }
 
-// GetDimensionsParams is parameters of getDimensions operation.
-type GetDimensionsParams struct {
-	ProjectId string
-}
-
-func unpackGetDimensionsParams(packed middleware.Parameters) (params GetDimensionsParams) {
-	{
-		key := middleware.ParameterKey{
-			Name: "projectId",
-			In:   "path",
-		}
-		params.ProjectId = packed[key].(string)
-	}
-	return params
-}
-
-func decodeGetDimensionsParams(args [1]string, argsEscaped bool, r *http.Request) (params GetDimensionsParams, _ error) {
-	// Decode path: projectId.
-	if err := func() error {
-		param := args[0]
-		if argsEscaped {
-			unescaped, err := url.PathUnescape(args[0])
-			if err != nil {
-				return errors.Wrap(err, "unescape path")
-			}
-			param = unescaped
-		}
-		if len(param) > 0 {
-			d := uri.NewPathDecoder(uri.PathDecoderConfig{
-				Param:   "projectId",
-				Value:   param,
-				Style:   uri.PathStyleSimple,
-				Explode: false,
-			})
-
-			if err := func() error {
-				val, err := d.DecodeValue()
-				if err != nil {
-					return err
-				}
-
-				c, err := conv.ToString(val)
-				if err != nil {
-					return err
-				}
-
-				params.ProjectId = c
-				return nil
-			}(); err != nil {
-				return err
-			}
-		} else {
-			return validate.ErrFieldRequired
-		}
-		return nil
-	}(); err != nil {
-		return params, &ogenerrors.DecodeParamError{
-			Name: "projectId",
-			In:   "path",
-			Err:  err,
-		}
-	}
-	return params, nil
-}
-
 // GetEventsParams is parameters of getEvents operation.
 type GetEventsParams struct {
 	JobId     string
@@ -2107,6 +2042,71 @@ func decodeGetProjectParams(args [1]string, argsEscaped bool, r *http.Request) (
 	return params, nil
 }
 
+// GetProjectDimensionsParams is parameters of getProjectDimensions operation.
+type GetProjectDimensionsParams struct {
+	ProjectId string
+}
+
+func unpackGetProjectDimensionsParams(packed middleware.Parameters) (params GetProjectDimensionsParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "projectId",
+			In:   "path",
+		}
+		params.ProjectId = packed[key].(string)
+	}
+	return params
+}
+
+func decodeGetProjectDimensionsParams(args [1]string, argsEscaped bool, r *http.Request) (params GetProjectDimensionsParams, _ error) {
+	// Decode path: projectId.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "projectId",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.ProjectId = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "projectId",
+			In:   "path",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
 // GetProjectLimitsParams is parameters of getProjectLimits operation.
 type GetProjectLimitsParams struct {
 	ProjectId string
@@ -2825,6 +2825,71 @@ func decodeGetTokenParams(args [0]string, argsEscaped bool, r *http.Request) (pa
 		return params, &ogenerrors.DecodeParamError{
 			Name: "X-Rescale-Environment",
 			In:   "header",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
+// GetWorkspaceDimensionsParams is parameters of getWorkspaceDimensions operation.
+type GetWorkspaceDimensionsParams struct {
+	WorkspaceId string
+}
+
+func unpackGetWorkspaceDimensionsParams(packed middleware.Parameters) (params GetWorkspaceDimensionsParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "workspaceId",
+			In:   "path",
+		}
+		params.WorkspaceId = packed[key].(string)
+	}
+	return params
+}
+
+func decodeGetWorkspaceDimensionsParams(args [1]string, argsEscaped bool, r *http.Request) (params GetWorkspaceDimensionsParams, _ error) {
+	// Decode path: workspaceId.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "workspaceId",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.WorkspaceId = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "workspaceId",
+			In:   "path",
 			Err:  err,
 		}
 	}
@@ -5927,71 +5992,6 @@ func decodeHtcStorageRegionRegionGetParams(args [1]string, argsEscaped bool, r *
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "region",
-			In:   "path",
-			Err:  err,
-		}
-	}
-	return params, nil
-}
-
-// HtcWorkspacesWorkspaceIdDimensionsGetParams is parameters of GET /htc/workspaces/{workspaceId}/dimensions operation.
-type HtcWorkspacesWorkspaceIdDimensionsGetParams struct {
-	WorkspaceId string
-}
-
-func unpackHtcWorkspacesWorkspaceIdDimensionsGetParams(packed middleware.Parameters) (params HtcWorkspacesWorkspaceIdDimensionsGetParams) {
-	{
-		key := middleware.ParameterKey{
-			Name: "workspaceId",
-			In:   "path",
-		}
-		params.WorkspaceId = packed[key].(string)
-	}
-	return params
-}
-
-func decodeHtcWorkspacesWorkspaceIdDimensionsGetParams(args [1]string, argsEscaped bool, r *http.Request) (params HtcWorkspacesWorkspaceIdDimensionsGetParams, _ error) {
-	// Decode path: workspaceId.
-	if err := func() error {
-		param := args[0]
-		if argsEscaped {
-			unescaped, err := url.PathUnescape(args[0])
-			if err != nil {
-				return errors.Wrap(err, "unescape path")
-			}
-			param = unescaped
-		}
-		if len(param) > 0 {
-			d := uri.NewPathDecoder(uri.PathDecoderConfig{
-				Param:   "workspaceId",
-				Value:   param,
-				Style:   uri.PathStyleSimple,
-				Explode: false,
-			})
-
-			if err := func() error {
-				val, err := d.DecodeValue()
-				if err != nil {
-					return err
-				}
-
-				c, err := conv.ToString(val)
-				if err != nil {
-					return err
-				}
-
-				params.WorkspaceId = c
-				return nil
-			}(); err != nil {
-				return err
-			}
-		} else {
-			return validate.ErrFieldRequired
-		}
-		return nil
-	}(); err != nil {
-		return params, &ogenerrors.DecodeParamError{
-			Name: "workspaceId",
 			In:   "path",
 			Err:  err,
 		}

--- a/v2/api/_oas/oas_request_decoders_gen.go
+++ b/v2/api/_oas/oas_request_decoders_gen.go
@@ -671,7 +671,7 @@ func (s *Server) decodeHtcProjectsProjectIdTasksTaskIdPatchRequest(r *http.Reque
 	}
 }
 
-func (s *Server) decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRequest(r *http.Request) (
+func (s *Server) decodePutTaskRetentionPolicyRequest(r *http.Request) (
 	req OptWorkspaceTaskRetentionPolicy,
 	close func() error,
 	rerr error,

--- a/v2/api/_oas/oas_request_encoders_gen.go
+++ b/v2/api/_oas/oas_request_encoders_gen.go
@@ -171,7 +171,7 @@ func encodeHtcProjectsProjectIdTasksTaskIdPatchRequest(
 	return nil
 }
 
-func encodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRequest(
+func encodePutTaskRetentionPolicyRequest(
 	req OptWorkspaceTaskRetentionPolicy,
 	r *http.Request,
 ) error {

--- a/v2/api/_oas/oas_response_decoders_gen.go
+++ b/v2/api/_oas/oas_response_decoders_gen.go
@@ -379,97 +379,6 @@ func decodeCreateTaskResponse(resp *http.Response) (res CreateTaskRes, _ error) 
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
 
-func decodeGetDimensionsResponse(resp *http.Response) (res GetDimensionsRes, _ error) {
-	switch resp.StatusCode {
-	case 200:
-		// Code 200.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response HTCProjectDimensions
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			// Validate response.
-			if err := func() error {
-				if err := response.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return res, errors.Wrap(err, "validate")
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	case 401:
-		// Code 401.
-		return &GetDimensionsUnauthorized{}, nil
-	case 403:
-		// Code 403.
-		return &GetDimensionsForbidden{}, nil
-	case 404:
-		// Code 404.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response OAuth2ErrorResponse
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	}
-	return res, validate.UnexpectedStatusCode(resp.StatusCode)
-}
-
 func decodeGetEventsResponse(resp *http.Response) (res GetEventsRes, _ error) {
 	switch resp.StatusCode {
 	case 200:
@@ -1211,6 +1120,97 @@ func decodeGetProjectResponse(resp *http.Response) (res GetProjectRes, _ error) 
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
 
+func decodeGetProjectDimensionsResponse(resp *http.Response) (res GetProjectDimensionsRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response HTCProjectDimensions
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		return &GetProjectDimensionsUnauthorized{}, nil
+	case 403:
+		// Code 403.
+		return &GetProjectDimensionsForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
 func decodeGetProjectLimitsResponse(resp *http.Response) (res GetProjectLimitsRes, _ error) {
 	switch resp.StatusCode {
 	case 200:
@@ -1762,6 +1762,97 @@ func decodeGetTokenResponse(resp *http.Response) (res GetTokenRes, _ error) {
 		}
 	case 401:
 		// Code 401.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeGetWorkspaceDimensionsResponse(resp *http.Response) (res GetWorkspaceDimensionsRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response HTCWorkspaceDimensions
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		return &GetWorkspaceDimensionsUnauthorized{}, nil
+	case 403:
+		// Code 403.
+		return &GetWorkspaceDimensionsForbidden{}, nil
+	case 404:
+		// Code 404.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 		if err != nil {
 			return res, errors.Wrap(err, "parse media type")
@@ -4232,97 +4323,6 @@ func decodeHtcStorageRegionRegionGetResponse(resp *http.Response) (res HtcStorag
 	case 403:
 		// Code 403.
 		return &HtcStorageRegionRegionGetForbidden{}, nil
-	case 404:
-		// Code 404.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response OAuth2ErrorResponse
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	}
-	return res, validate.UnexpectedStatusCode(resp.StatusCode)
-}
-
-func decodeHtcWorkspacesWorkspaceIdDimensionsGetResponse(resp *http.Response) (res HtcWorkspacesWorkspaceIdDimensionsGetRes, _ error) {
-	switch resp.StatusCode {
-	case 200:
-		// Code 200.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			// Validate response.
-			if err := func() error {
-				if err := response.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return res, errors.Wrap(err, "validate")
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	case 401:
-		// Code 401.
-		return &HtcWorkspacesWorkspaceIdDimensionsGetUnauthorized{}, nil
-	case 403:
-		// Code 403.
-		return &HtcWorkspacesWorkspaceIdDimensionsGetForbidden{}, nil
 	case 404:
 		// Code 404.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))

--- a/v2/api/_oas/oas_response_decoders_gen.go
+++ b/v2/api/_oas/oas_response_decoders_gen.go
@@ -1007,97 +1007,6 @@ func decodeGetJobsResponse(resp *http.Response) (res GetJobsRes, _ error) {
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
 
-func decodeGetLimitsResponse(resp *http.Response) (res GetLimitsRes, _ error) {
-	switch resp.StatusCode {
-	case 200:
-		// Code 200.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response HTCProjectLimits
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			// Validate response.
-			if err := func() error {
-				if err := response.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return res, errors.Wrap(err, "validate")
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	case 401:
-		// Code 401.
-		return &GetLimitsUnauthorized{}, nil
-	case 403:
-		// Code 403.
-		return &GetLimitsForbidden{}, nil
-	case 404:
-		// Code 404.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response OAuth2ErrorResponse
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	}
-	return res, validate.UnexpectedStatusCode(resp.StatusCode)
-}
-
 func decodeGetLogsResponse(resp *http.Response) (res GetLogsRes, _ error) {
 	switch resp.StatusCode {
 	case 200:
@@ -1302,6 +1211,97 @@ func decodeGetProjectResponse(resp *http.Response) (res GetProjectRes, _ error) 
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
 
+func decodeGetProjectLimitsResponse(resp *http.Response) (res GetProjectLimitsRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response HTCProjectLimits
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		return &GetProjectLimitsUnauthorized{}, nil
+	case 403:
+		// Code 403.
+		return &GetProjectLimitsForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
 func decodeGetProjectsResponse(resp *http.Response) (res GetProjectsRes, _ error) {
 	switch resp.StatusCode {
 	case 200:
@@ -1420,6 +1420,97 @@ func decodeGetRegistryTokenResponse(resp *http.Response) (res GetRegistryTokenRe
 	case 403:
 		// Code 403.
 		return &GetRegistryTokenForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeGetTaskRetentionPolicyResponse(resp *http.Response) (res GetTaskRetentionPolicyRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response WorkspaceTaskRetentionPolicy
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		return &GetTaskRetentionPolicyUnauthorized{}, nil
+	case 403:
+		// Code 403.
+		return &GetTaskRetentionPolicyForbidden{}, nil
 	case 404:
 		// Code 404.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
@@ -1671,6 +1762,97 @@ func decodeGetTokenResponse(resp *http.Response) (res GetTokenRes, _ error) {
 		}
 	case 401:
 		// Code 401.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeGetWorkspaceLimitsResponse(resp *http.Response) (res GetWorkspaceLimitsRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response HTCWorkspaceLimit
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		return &GetWorkspaceLimitsUnauthorized{}, nil
+	case 403:
+		// Code 403.
+		return &GetWorkspaceLimitsForbidden{}, nil
+	case 404:
+		// Code 404.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 		if err != nil {
 			return res, errors.Wrap(err, "parse media type")
@@ -4180,279 +4362,6 @@ func decodeHtcWorkspacesWorkspaceIdDimensionsGetResponse(resp *http.Response) (r
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
 
-func decodeHtcWorkspacesWorkspaceIdLimitsGetResponse(resp *http.Response) (res HtcWorkspacesWorkspaceIdLimitsGetRes, _ error) {
-	switch resp.StatusCode {
-	case 200:
-		// Code 200.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response HTCWorkspaceLimit
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			// Validate response.
-			if err := func() error {
-				if err := response.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return res, errors.Wrap(err, "validate")
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	case 401:
-		// Code 401.
-		return &HtcWorkspacesWorkspaceIdLimitsGetUnauthorized{}, nil
-	case 403:
-		// Code 403.
-		return &HtcWorkspacesWorkspaceIdLimitsGetForbidden{}, nil
-	case 404:
-		// Code 404.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response OAuth2ErrorResponse
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	}
-	return res, validate.UnexpectedStatusCode(resp.StatusCode)
-}
-
-func decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetResponse(resp *http.Response) (res HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes, _ error) {
-	switch resp.StatusCode {
-	case 200:
-		// Code 200.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response WorkspaceTaskRetentionPolicy
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			// Validate response.
-			if err := func() error {
-				if err := response.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return res, errors.Wrap(err, "validate")
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	case 401:
-		// Code 401.
-		return &HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetUnauthorized{}, nil
-	case 403:
-		// Code 403.
-		return &HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetForbidden{}, nil
-	case 404:
-		// Code 404.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response OAuth2ErrorResponse
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	}
-	return res, validate.UnexpectedStatusCode(resp.StatusCode)
-}
-
-func decodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutResponse(resp *http.Response) (res HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes, _ error) {
-	switch resp.StatusCode {
-	case 201:
-		// Code 201.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response WorkspaceTaskRetentionPolicy
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			// Validate response.
-			if err := func() error {
-				if err := response.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return res, errors.Wrap(err, "validate")
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	case 401:
-		// Code 401.
-		return &HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutUnauthorized{}, nil
-	case 403:
-		// Code 403.
-		return &HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutForbidden{}, nil
-	case 404:
-		// Code 404.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response OAuth2ErrorResponse
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	}
-	return res, validate.UnexpectedStatusCode(resp.StatusCode)
-}
-
 func decodeOAuth2TokenPostResponse(resp *http.Response) (res OAuth2TokenPostRes, _ error) {
 	switch resp.StatusCode {
 	case 200:
@@ -4525,6 +4434,100 @@ func decodeOAuth2TokenPostResponse(resp *http.Response) (res OAuth2TokenPostRes,
 		default:
 			return res, validate.InvalidContentType(ct)
 		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodePutTaskRetentionPolicyResponse(resp *http.Response) (res PutTaskRetentionPolicyRes, _ error) {
+	switch resp.StatusCode {
+	case 201:
+		// Code 201.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response WorkspaceTaskRetentionPolicy
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		return &PutTaskRetentionPolicyUnauthorized{}, nil
+	case 403:
+		// Code 403.
+		return &PutTaskRetentionPolicyForbidden{}, nil
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OAuth2ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 405:
+		// Code 405.
+		return &PutTaskRetentionPolicyMethodNotAllowed{}, nil
 	}
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }

--- a/v2/api/_oas/oas_response_encoders_gen.go
+++ b/v2/api/_oas/oas_response_encoders_gen.go
@@ -486,47 +486,6 @@ func encodeGetJobsResponse(response GetJobsRes, w http.ResponseWriter) error {
 	}
 }
 
-func encodeGetLimitsResponse(response GetLimitsRes, w http.ResponseWriter) error {
-	switch response := response.(type) {
-	case *HTCProjectLimits:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(200)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	case *GetLimitsUnauthorized:
-		w.WriteHeader(401)
-
-		return nil
-
-	case *GetLimitsForbidden:
-		w.WriteHeader(403)
-
-		return nil
-
-	case *OAuth2ErrorResponse:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(404)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	default:
-		return errors.Errorf("unexpected response type: %T", response)
-	}
-}
-
 func encodeGetLogsResponse(response GetLogsRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
 	case *HTCJobLogs:
@@ -637,6 +596,47 @@ func encodeGetProjectResponse(response GetProjectRes, w http.ResponseWriter) err
 	}
 }
 
+func encodeGetProjectLimitsResponse(response GetProjectLimitsRes, w http.ResponseWriter) error {
+	switch response := response.(type) {
+	case *HTCProjectLimits:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *GetProjectLimitsUnauthorized:
+		w.WriteHeader(401)
+
+		return nil
+
+	case *GetProjectLimitsForbidden:
+		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
 func encodeGetProjectsResponse(response GetProjectsRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
 	case *HTCProjectsResponse:
@@ -700,6 +700,47 @@ func encodeGetRegistryTokenResponse(response GetRegistryTokenRes, w http.Respons
 		return nil
 
 	case *GetRegistryTokenForbidden:
+		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
+func encodeGetTaskRetentionPolicyResponse(response GetTaskRetentionPolicyRes, w http.ResponseWriter) error {
+	switch response := response.(type) {
+	case *WorkspaceTaskRetentionPolicy:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *GetTaskRetentionPolicyUnauthorized:
+		w.WriteHeader(401)
+
+		return nil
+
+	case *GetTaskRetentionPolicyForbidden:
 		w.WriteHeader(403)
 
 		return nil
@@ -820,6 +861,47 @@ func encodeGetTokenResponse(response GetTokenRes, w http.ResponseWriter) error {
 	case *OAuth2ErrorResponse:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(401)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
+func encodeGetWorkspaceLimitsResponse(response GetWorkspaceLimitsRes, w http.ResponseWriter) error {
+	switch response := response.(type) {
+	case *HTCWorkspaceLimit:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *GetWorkspaceLimitsUnauthorized:
+		w.WriteHeader(401)
+
+		return nil
+
+	case *GetWorkspaceLimitsForbidden:
+		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
 		response.Encode(e)
@@ -1990,129 +2072,6 @@ func encodeHtcWorkspacesWorkspaceIdDimensionsGetResponse(response HtcWorkspacesW
 	}
 }
 
-func encodeHtcWorkspacesWorkspaceIdLimitsGetResponse(response HtcWorkspacesWorkspaceIdLimitsGetRes, w http.ResponseWriter) error {
-	switch response := response.(type) {
-	case *HTCWorkspaceLimit:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(200)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	case *HtcWorkspacesWorkspaceIdLimitsGetUnauthorized:
-		w.WriteHeader(401)
-
-		return nil
-
-	case *HtcWorkspacesWorkspaceIdLimitsGetForbidden:
-		w.WriteHeader(403)
-
-		return nil
-
-	case *OAuth2ErrorResponse:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(404)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	default:
-		return errors.Errorf("unexpected response type: %T", response)
-	}
-}
-
-func encodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetResponse(response HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes, w http.ResponseWriter) error {
-	switch response := response.(type) {
-	case *WorkspaceTaskRetentionPolicy:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(200)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	case *HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetUnauthorized:
-		w.WriteHeader(401)
-
-		return nil
-
-	case *HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetForbidden:
-		w.WriteHeader(403)
-
-		return nil
-
-	case *OAuth2ErrorResponse:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(404)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	default:
-		return errors.Errorf("unexpected response type: %T", response)
-	}
-}
-
-func encodeHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutResponse(response HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes, w http.ResponseWriter) error {
-	switch response := response.(type) {
-	case *WorkspaceTaskRetentionPolicy:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(201)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	case *HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutUnauthorized:
-		w.WriteHeader(401)
-
-		return nil
-
-	case *HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutForbidden:
-		w.WriteHeader(403)
-
-		return nil
-
-	case *OAuth2ErrorResponse:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(404)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	default:
-		return errors.Errorf("unexpected response type: %T", response)
-	}
-}
-
 func encodeOAuth2TokenPostResponse(response OAuth2TokenPostRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
 	case *OAuth2Token:
@@ -2136,6 +2095,52 @@ func encodeOAuth2TokenPostResponse(response OAuth2TokenPostRes, w http.ResponseW
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
+func encodePutTaskRetentionPolicyResponse(response PutTaskRetentionPolicyRes, w http.ResponseWriter) error {
+	switch response := response.(type) {
+	case *WorkspaceTaskRetentionPolicy:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(201)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *PutTaskRetentionPolicyUnauthorized:
+		w.WriteHeader(401)
+
+		return nil
+
+	case *PutTaskRetentionPolicyForbidden:
+		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *PutTaskRetentionPolicyMethodNotAllowed:
+		w.WriteHeader(405)
 
 		return nil
 

--- a/v2/api/_oas/oas_response_encoders_gen.go
+++ b/v2/api/_oas/oas_response_encoders_gen.go
@@ -199,47 +199,6 @@ func encodeCreateTaskResponse(response CreateTaskRes, w http.ResponseWriter) err
 	}
 }
 
-func encodeGetDimensionsResponse(response GetDimensionsRes, w http.ResponseWriter) error {
-	switch response := response.(type) {
-	case *HTCProjectDimensions:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(200)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	case *GetDimensionsUnauthorized:
-		w.WriteHeader(401)
-
-		return nil
-
-	case *GetDimensionsForbidden:
-		w.WriteHeader(403)
-
-		return nil
-
-	case *OAuth2ErrorResponse:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(404)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	default:
-		return errors.Errorf("unexpected response type: %T", response)
-	}
-}
-
 func encodeGetEventsResponse(response GetEventsRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
 	case *HTCJobStatusEvents:
@@ -596,6 +555,47 @@ func encodeGetProjectResponse(response GetProjectRes, w http.ResponseWriter) err
 	}
 }
 
+func encodeGetProjectDimensionsResponse(response GetProjectDimensionsRes, w http.ResponseWriter) error {
+	switch response := response.(type) {
+	case *HTCProjectDimensions:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *GetProjectDimensionsUnauthorized:
+		w.WriteHeader(401)
+
+		return nil
+
+	case *GetProjectDimensionsForbidden:
+		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
 func encodeGetProjectLimitsResponse(response GetProjectLimitsRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
 	case *HTCProjectLimits:
@@ -861,6 +861,47 @@ func encodeGetTokenResponse(response GetTokenRes, w http.ResponseWriter) error {
 	case *OAuth2ErrorResponse:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(401)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
+func encodeGetWorkspaceDimensionsResponse(response GetWorkspaceDimensionsRes, w http.ResponseWriter) error {
+	switch response := response.(type) {
+	case *HTCWorkspaceDimensions:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *GetWorkspaceDimensionsUnauthorized:
+		w.WriteHeader(401)
+
+		return nil
+
+	case *GetWorkspaceDimensionsForbidden:
+		w.WriteHeader(403)
+
+		return nil
+
+	case *OAuth2ErrorResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
 		response.Encode(e)
@@ -2010,47 +2051,6 @@ func encodeHtcStorageRegionRegionGetResponse(response HtcStorageRegionRegionGetR
 		return nil
 
 	case *HtcStorageRegionRegionGetForbidden:
-		w.WriteHeader(403)
-
-		return nil
-
-	case *OAuth2ErrorResponse:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(404)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	default:
-		return errors.Errorf("unexpected response type: %T", response)
-	}
-}
-
-func encodeHtcWorkspacesWorkspaceIdDimensionsGetResponse(response HtcWorkspacesWorkspaceIdDimensionsGetRes, w http.ResponseWriter) error {
-	switch response := response.(type) {
-	case *HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON:
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(200)
-
-		e := new(jx.Encoder)
-		response.Encode(e)
-		if _, err := e.WriteTo(w); err != nil {
-			return errors.Wrap(err, "write")
-		}
-
-		return nil
-
-	case *HtcWorkspacesWorkspaceIdDimensionsGetUnauthorized:
-		w.WriteHeader(401)
-
-		return nil
-
-	case *HtcWorkspacesWorkspaceIdDimensionsGetForbidden:
 		w.WriteHeader(403)
 
 		return nil

--- a/v2/api/_oas/oas_router_gen.go
+++ b/v2/api/_oas/oas_router_gen.go
@@ -421,7 +421,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									// Leaf node.
 									switch r.Method {
 									case "GET":
-										s.handleGetDimensionsRequest([1]string{
+										s.handleGetProjectDimensionsRequest([1]string{
 											args[0],
 										}, elemIsEscaped, w, r)
 									case "PUT":
@@ -1330,7 +1330,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								// Leaf node.
 								switch r.Method {
 								case "GET":
-									s.handleHtcWorkspacesWorkspaceIdDimensionsGetRequest([1]string{
+									s.handleGetWorkspaceDimensionsRequest([1]string{
 										args[0],
 									}, elemIsEscaped, w, r)
 								default:
@@ -1920,9 +1920,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									// Leaf node.
 									switch method {
 									case "GET":
-										r.name = "GetDimensions"
+										r.name = "GetProjectDimensions"
 										r.summary = "Get Project Dimensions"
-										r.operationID = "getDimensions"
+										r.operationID = "getProjectDimensions"
 										r.pathPattern = "/htc/projects/{projectId}/dimensions"
 										r.args = args
 										r.count = 1
@@ -2904,9 +2904,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								// Leaf node.
 								switch method {
 								case "GET":
-									r.name = "HtcWorkspacesWorkspaceIdDimensionsGet"
+									r.name = "GetWorkspaceDimensions"
 									r.summary = "Get Workspace Dimensions"
-									r.operationID = ""
+									r.operationID = "getWorkspaceDimensions"
 									r.pathPattern = "/htc/workspaces/{workspaceId}/dimensions"
 									r.args = args
 									r.count = 1

--- a/v2/api/_oas/oas_router_gen.go
+++ b/v2/api/_oas/oas_router_gen.go
@@ -451,7 +451,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											args[0],
 										}, elemIsEscaped, w, r)
 									case "GET":
-										s.handleGetLimitsRequest([1]string{
+										s.handleGetProjectLimitsRequest([1]string{
 											args[0],
 										}, elemIsEscaped, w, r)
 									case "POST":
@@ -1353,7 +1353,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								// Leaf node.
 								switch r.Method {
 								case "GET":
-									s.handleHtcWorkspacesWorkspaceIdLimitsGetRequest([1]string{
+									s.handleGetWorkspaceLimitsRequest([1]string{
 										args[0],
 									}, elemIsEscaped, w, r)
 								default:
@@ -1376,11 +1376,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								// Leaf node.
 								switch r.Method {
 								case "GET":
-									s.handleHtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRequest([1]string{
+									s.handleGetTaskRetentionPolicyRequest([1]string{
 										args[0],
 									}, elemIsEscaped, w, r)
 								case "PUT":
-									s.handleHtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRequest([1]string{
+									s.handlePutTaskRetentionPolicyRequest([1]string{
 										args[0],
 									}, elemIsEscaped, w, r)
 								default:
@@ -1960,9 +1960,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										r.count = 1
 										return r, true
 									case "GET":
-										r.name = "GetLimits"
+										r.name = "GetProjectLimits"
 										r.summary = "Get Project Limits"
-										r.operationID = "getLimits"
+										r.operationID = "getProjectLimits"
 										r.pathPattern = "/htc/projects/{projectId}/limits"
 										r.args = args
 										r.count = 1
@@ -2929,9 +2929,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								// Leaf node.
 								switch method {
 								case "GET":
-									r.name = "HtcWorkspacesWorkspaceIdLimitsGet"
+									r.name = "GetWorkspaceLimits"
 									r.summary = "Get Workspace Limit"
-									r.operationID = ""
+									r.operationID = "getWorkspaceLimits"
 									r.pathPattern = "/htc/workspaces/{workspaceId}/limits"
 									r.args = args
 									r.count = 1
@@ -2954,17 +2954,17 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								// Leaf node.
 								switch method {
 								case "GET":
-									r.name = "HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet"
+									r.name = "GetTaskRetentionPolicy"
 									r.summary = "Get Workspace Task Retention Policy"
-									r.operationID = ""
+									r.operationID = "getTaskRetentionPolicy"
 									r.pathPattern = "/htc/workspaces/{workspaceId}/task-retention-policy"
 									r.args = args
 									r.count = 1
 									return r, true
 								case "PUT":
-									r.name = "HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut"
+									r.name = "PutTaskRetentionPolicy"
 									r.summary = "Modify Workspace Task Retention Policy"
-									r.operationID = ""
+									r.operationID = "putTaskRetentionPolicy"
 									r.pathPattern = "/htc/workspaces/{workspaceId}/task-retention-policy"
 									r.args = args
 									r.count = 1

--- a/v2/api/_oas/oas_schemas_gen.go
+++ b/v2/api/_oas/oas_schemas_gen.go
@@ -413,16 +413,6 @@ func (s *FeatureFlagsResult) SetResults(val []RescaleFlag) {
 	s.Results = val
 }
 
-// GetDimensionsForbidden is response for GetDimensions operation.
-type GetDimensionsForbidden struct{}
-
-func (*GetDimensionsForbidden) getDimensionsRes() {}
-
-// GetDimensionsUnauthorized is response for GetDimensions operation.
-type GetDimensionsUnauthorized struct{}
-
-func (*GetDimensionsUnauthorized) getDimensionsRes() {}
-
 // GetEventsForbidden is response for GetEvents operation.
 type GetEventsForbidden struct{}
 
@@ -587,6 +577,16 @@ type GetMetricsUnauthorized struct{}
 
 func (*GetMetricsUnauthorized) getMetricsRes() {}
 
+// GetProjectDimensionsForbidden is response for GetProjectDimensions operation.
+type GetProjectDimensionsForbidden struct{}
+
+func (*GetProjectDimensionsForbidden) getProjectDimensionsRes() {}
+
+// GetProjectDimensionsUnauthorized is response for GetProjectDimensions operation.
+type GetProjectDimensionsUnauthorized struct{}
+
+func (*GetProjectDimensionsUnauthorized) getProjectDimensionsRes() {}
+
 // GetProjectForbidden is response for GetProject operation.
 type GetProjectForbidden struct{}
 
@@ -698,6 +698,16 @@ func (*GetTasksForbidden) getTasksRes() {}
 type GetTasksUnauthorized struct{}
 
 func (*GetTasksUnauthorized) getTasksRes() {}
+
+// GetWorkspaceDimensionsForbidden is response for GetWorkspaceDimensions operation.
+type GetWorkspaceDimensionsForbidden struct{}
+
+func (*GetWorkspaceDimensionsForbidden) getWorkspaceDimensionsRes() {}
+
+// GetWorkspaceDimensionsUnauthorized is response for GetWorkspaceDimensions operation.
+type GetWorkspaceDimensionsUnauthorized struct{}
+
+func (*GetWorkspaceDimensionsUnauthorized) getWorkspaceDimensionsRes() {}
 
 // GetWorkspaceLimitsForbidden is response for GetWorkspaceLimits operation.
 type GetWorkspaceLimitsForbidden struct{}
@@ -2649,7 +2659,7 @@ func (*HTCProject) htcProjectsProjectIdPatchRes() {}
 
 type HTCProjectDimensions []HTCComputeEnvironment
 
-func (*HTCProjectDimensions) getDimensionsRes() {}
+func (*HTCProjectDimensions) getProjectDimensionsRes() {}
 
 // Ref: #/components/schemas/HTCProjectLimit
 type HTCProjectLimit struct {
@@ -3674,6 +3684,10 @@ type HTCTokenPayload string
 
 func (*HTCTokenPayload) authTokenWhoamiGetRes() {}
 
+type HTCWorkspaceDimensions []HTCComputeEnvironment
+
+func (*HTCWorkspaceDimensions) getWorkspaceDimensionsRes() {}
+
 // Ref: #/components/schemas/HTCWorkspaceLimit
 type HTCWorkspaceLimit struct {
 	CreatedAt   OptDateTime `json:"createdAt"`
@@ -4271,22 +4285,6 @@ type HtcStorageRegionRegionGetUnauthorized struct{}
 
 func (*HtcStorageRegionRegionGetUnauthorized) htcStorageRegionRegionGetRes() {}
 
-// HtcWorkspacesWorkspaceIdDimensionsGetForbidden is response for HtcWorkspacesWorkspaceIdDimensionsGet operation.
-type HtcWorkspacesWorkspaceIdDimensionsGetForbidden struct{}
-
-func (*HtcWorkspacesWorkspaceIdDimensionsGetForbidden) htcWorkspacesWorkspaceIdDimensionsGetRes() {}
-
-type HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON []HTCComputeEnvironment
-
-func (*HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON) htcWorkspacesWorkspaceIdDimensionsGetRes() {
-}
-
-// HtcWorkspacesWorkspaceIdDimensionsGetUnauthorized is response for HtcWorkspacesWorkspaceIdDimensionsGet operation.
-type HtcWorkspacesWorkspaceIdDimensionsGetUnauthorized struct{}
-
-func (*HtcWorkspacesWorkspaceIdDimensionsGetUnauthorized) htcWorkspacesWorkspaceIdDimensionsGetRes() {
-}
-
 // Ref: #/components/schemas/InstanceLabels
 type InstanceLabels struct {
 	AccountId            OptString `json:"accountId"`
@@ -4747,9 +4745,9 @@ func (s *OAuth2ErrorResponse) SetErrorDescription(val OptString) {
 func (*OAuth2ErrorResponse) authTokenWhoamiGetRes()                                       {}
 func (*OAuth2ErrorResponse) createRepoRes()                                               {}
 func (*OAuth2ErrorResponse) createTaskRes()                                               {}
-func (*OAuth2ErrorResponse) getDimensionsRes()                                            {}
 func (*OAuth2ErrorResponse) getGCPClustersRes()                                           {}
 func (*OAuth2ErrorResponse) getImagesRes()                                                {}
+func (*OAuth2ErrorResponse) getProjectDimensionsRes()                                     {}
 func (*OAuth2ErrorResponse) getProjectLimitsRes()                                         {}
 func (*OAuth2ErrorResponse) getProjectRes()                                               {}
 func (*OAuth2ErrorResponse) getRegistryTokenRes()                                         {}
@@ -4757,6 +4755,7 @@ func (*OAuth2ErrorResponse) getTaskRetentionPolicyRes()                         
 func (*OAuth2ErrorResponse) getTaskStatsRes()                                             {}
 func (*OAuth2ErrorResponse) getTasksRes()                                                 {}
 func (*OAuth2ErrorResponse) getTokenRes()                                                 {}
+func (*OAuth2ErrorResponse) getWorkspaceDimensionsRes()                                   {}
 func (*OAuth2ErrorResponse) getWorkspaceLimitsRes()                                       {}
 func (*OAuth2ErrorResponse) htcProjectsProjectIdDimensionsPutRes()                        {}
 func (*OAuth2ErrorResponse) htcProjectsProjectIdLimitsDeleteRes()                         {}
@@ -4785,7 +4784,6 @@ func (*OAuth2ErrorResponse) htcProjectsProjectIdTasksTaskIdStorageTokensGetRes()
 func (*OAuth2ErrorResponse) htcRegionsGetRes()                                            {}
 func (*OAuth2ErrorResponse) htcRegionsRegionGetRes()                                      {}
 func (*OAuth2ErrorResponse) htcStorageRegionRegionGetRes()                                {}
-func (*OAuth2ErrorResponse) htcWorkspacesWorkspaceIdDimensionsGetRes()                    {}
 func (*OAuth2ErrorResponse) oAuth2TokenPostRes()                                          {}
 func (*OAuth2ErrorResponse) putTaskRetentionPolicyRes()                                   {}
 func (*OAuth2ErrorResponse) submitJobsRes()                                               {}

--- a/v2/api/_oas/oas_schemas_gen.go
+++ b/v2/api/_oas/oas_schemas_gen.go
@@ -510,16 +510,6 @@ type GetJobsUnauthorized struct{}
 
 func (*GetJobsUnauthorized) getJobsRes() {}
 
-// GetLimitsForbidden is response for GetLimits operation.
-type GetLimitsForbidden struct{}
-
-func (*GetLimitsForbidden) getLimitsRes() {}
-
-// GetLimitsUnauthorized is response for GetLimits operation.
-type GetLimitsUnauthorized struct{}
-
-func (*GetLimitsUnauthorized) getLimitsRes() {}
-
 // GetLogsForbidden is response for GetLogs operation.
 type GetLogsForbidden struct{}
 
@@ -602,6 +592,16 @@ type GetProjectForbidden struct{}
 
 func (*GetProjectForbidden) getProjectRes() {}
 
+// GetProjectLimitsForbidden is response for GetProjectLimits operation.
+type GetProjectLimitsForbidden struct{}
+
+func (*GetProjectLimitsForbidden) getProjectLimitsRes() {}
+
+// GetProjectLimitsUnauthorized is response for GetProjectLimits operation.
+type GetProjectLimitsUnauthorized struct{}
+
+func (*GetProjectLimitsUnauthorized) getProjectLimitsRes() {}
+
 // GetProjectUnauthorized is response for GetProject operation.
 type GetProjectUnauthorized struct{}
 
@@ -669,6 +669,16 @@ type GetRegistryTokenUnauthorized struct{}
 
 func (*GetRegistryTokenUnauthorized) getRegistryTokenRes() {}
 
+// GetTaskRetentionPolicyForbidden is response for GetTaskRetentionPolicy operation.
+type GetTaskRetentionPolicyForbidden struct{}
+
+func (*GetTaskRetentionPolicyForbidden) getTaskRetentionPolicyRes() {}
+
+// GetTaskRetentionPolicyUnauthorized is response for GetTaskRetentionPolicy operation.
+type GetTaskRetentionPolicyUnauthorized struct{}
+
+func (*GetTaskRetentionPolicyUnauthorized) getTaskRetentionPolicyRes() {}
+
 // GetTaskStatsForbidden is response for GetTaskStats operation.
 type GetTaskStatsForbidden struct{}
 
@@ -688,6 +698,16 @@ func (*GetTasksForbidden) getTasksRes() {}
 type GetTasksUnauthorized struct{}
 
 func (*GetTasksUnauthorized) getTasksRes() {}
+
+// GetWorkspaceLimitsForbidden is response for GetWorkspaceLimits operation.
+type GetWorkspaceLimitsForbidden struct{}
+
+func (*GetWorkspaceLimitsForbidden) getWorkspaceLimitsRes() {}
+
+// GetWorkspaceLimitsUnauthorized is response for GetWorkspaceLimits operation.
+type GetWorkspaceLimitsUnauthorized struct{}
+
+func (*GetWorkspaceLimitsUnauthorized) getWorkspaceLimitsRes() {}
 
 // Ref: #/components/schemas/HTCCluster
 type HTCCluster struct {
@@ -2782,7 +2802,7 @@ func (s *HTCProjectLimitModifierRole) UnmarshalText(data []byte) error {
 
 type HTCProjectLimits []HTCProjectLimit
 
-func (*HTCProjectLimits) getLimitsRes() {}
+func (*HTCProjectLimits) getProjectLimitsRes() {}
 
 // Ref: #/components/schemas/HTCProjectUpdate
 type HTCProjectUpdate struct {
@@ -3724,7 +3744,7 @@ func (s *HTCWorkspaceLimit) SetWorkspaceId(val OptString) {
 	s.WorkspaceId = val
 }
 
-func (*HTCWorkspaceLimit) htcWorkspacesWorkspaceIdLimitsGetRes() {}
+func (*HTCWorkspaceLimit) getWorkspaceLimitsRes() {}
 
 type HtcProjectsProjectIdDimensionsPutCreatedApplicationJSON []HTCComputeEnvironment
 
@@ -4267,40 +4287,6 @@ type HtcWorkspacesWorkspaceIdDimensionsGetUnauthorized struct{}
 func (*HtcWorkspacesWorkspaceIdDimensionsGetUnauthorized) htcWorkspacesWorkspaceIdDimensionsGetRes() {
 }
 
-// HtcWorkspacesWorkspaceIdLimitsGetForbidden is response for HtcWorkspacesWorkspaceIdLimitsGet operation.
-type HtcWorkspacesWorkspaceIdLimitsGetForbidden struct{}
-
-func (*HtcWorkspacesWorkspaceIdLimitsGetForbidden) htcWorkspacesWorkspaceIdLimitsGetRes() {}
-
-// HtcWorkspacesWorkspaceIdLimitsGetUnauthorized is response for HtcWorkspacesWorkspaceIdLimitsGet operation.
-type HtcWorkspacesWorkspaceIdLimitsGetUnauthorized struct{}
-
-func (*HtcWorkspacesWorkspaceIdLimitsGetUnauthorized) htcWorkspacesWorkspaceIdLimitsGetRes() {}
-
-// HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetForbidden is response for HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet operation.
-type HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetForbidden struct{}
-
-func (*HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetForbidden) htcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes() {
-}
-
-// HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetUnauthorized is response for HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet operation.
-type HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetUnauthorized struct{}
-
-func (*HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetUnauthorized) htcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes() {
-}
-
-// HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutForbidden is response for HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut operation.
-type HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutForbidden struct{}
-
-func (*HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutForbidden) htcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes() {
-}
-
-// HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutUnauthorized is response for HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut operation.
-type HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutUnauthorized struct{}
-
-func (*HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutUnauthorized) htcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes() {
-}
-
 // Ref: #/components/schemas/InstanceLabels
 type InstanceLabels struct {
 	AccountId            OptString `json:"accountId"`
@@ -4764,12 +4750,14 @@ func (*OAuth2ErrorResponse) createTaskRes()                                     
 func (*OAuth2ErrorResponse) getDimensionsRes()                                            {}
 func (*OAuth2ErrorResponse) getGCPClustersRes()                                           {}
 func (*OAuth2ErrorResponse) getImagesRes()                                                {}
-func (*OAuth2ErrorResponse) getLimitsRes()                                                {}
+func (*OAuth2ErrorResponse) getProjectLimitsRes()                                         {}
 func (*OAuth2ErrorResponse) getProjectRes()                                               {}
 func (*OAuth2ErrorResponse) getRegistryTokenRes()                                         {}
+func (*OAuth2ErrorResponse) getTaskRetentionPolicyRes()                                   {}
 func (*OAuth2ErrorResponse) getTaskStatsRes()                                             {}
 func (*OAuth2ErrorResponse) getTasksRes()                                                 {}
 func (*OAuth2ErrorResponse) getTokenRes()                                                 {}
+func (*OAuth2ErrorResponse) getWorkspaceLimitsRes()                                       {}
 func (*OAuth2ErrorResponse) htcProjectsProjectIdDimensionsPutRes()                        {}
 func (*OAuth2ErrorResponse) htcProjectsProjectIdLimitsDeleteRes()                         {}
 func (*OAuth2ErrorResponse) htcProjectsProjectIdLimitsIDDeleteRes()                       {}
@@ -4798,10 +4786,8 @@ func (*OAuth2ErrorResponse) htcRegionsGetRes()                                  
 func (*OAuth2ErrorResponse) htcRegionsRegionGetRes()                                      {}
 func (*OAuth2ErrorResponse) htcStorageRegionRegionGetRes()                                {}
 func (*OAuth2ErrorResponse) htcWorkspacesWorkspaceIdDimensionsGetRes()                    {}
-func (*OAuth2ErrorResponse) htcWorkspacesWorkspaceIdLimitsGetRes()                        {}
-func (*OAuth2ErrorResponse) htcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes()           {}
-func (*OAuth2ErrorResponse) htcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes()           {}
 func (*OAuth2ErrorResponse) oAuth2TokenPostRes()                                          {}
+func (*OAuth2ErrorResponse) putTaskRetentionPolicyRes()                                   {}
 func (*OAuth2ErrorResponse) submitJobsRes()                                               {}
 func (*OAuth2ErrorResponse) wellKnownJwksJSONGetRes()                                     {}
 func (*OAuth2ErrorResponse) whoAmIRes()                                                   {}
@@ -7733,6 +7719,21 @@ func (s *PublicKey) SetFormat(val OptString) {
 	s.Format = val
 }
 
+// PutTaskRetentionPolicyForbidden is response for PutTaskRetentionPolicy operation.
+type PutTaskRetentionPolicyForbidden struct{}
+
+func (*PutTaskRetentionPolicyForbidden) putTaskRetentionPolicyRes() {}
+
+// PutTaskRetentionPolicyMethodNotAllowed is response for PutTaskRetentionPolicy operation.
+type PutTaskRetentionPolicyMethodNotAllowed struct{}
+
+func (*PutTaskRetentionPolicyMethodNotAllowed) putTaskRetentionPolicyRes() {}
+
+// PutTaskRetentionPolicyUnauthorized is response for PutTaskRetentionPolicy operation.
+type PutTaskRetentionPolicyUnauthorized struct{}
+
+func (*PutTaskRetentionPolicyUnauthorized) putTaskRetentionPolicyRes() {}
+
 // Ref: #/components/schemas/RegionStorageOption
 type RegionStorageOption struct {
 	Provider    OptCloudProvider `json:"provider"`
@@ -9161,5 +9162,5 @@ func (s *WorkspaceTaskRetentionPolicy) SetWorkspaceId(val OptString) {
 	s.WorkspaceId = val
 }
 
-func (*WorkspaceTaskRetentionPolicy) htcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes() {}
-func (*WorkspaceTaskRetentionPolicy) htcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes() {}
+func (*WorkspaceTaskRetentionPolicy) getTaskRetentionPolicyRes() {}
+func (*WorkspaceTaskRetentionPolicy) putTaskRetentionPolicyRes() {}

--- a/v2/api/_oas/oas_server_gen.go
+++ b/v2/api/_oas/oas_server_gen.go
@@ -267,51 +267,6 @@ type Handler interface {
 	//
 	// GET /htc/workspaces/{workspaceId}/dimensions
 	HtcWorkspacesWorkspaceIdDimensionsGet(ctx context.Context, params HtcWorkspacesWorkspaceIdDimensionsGetParams) (HtcWorkspacesWorkspaceIdDimensionsGetRes, error)
-	// HtcWorkspacesWorkspaceIdLimitsGet implements GET /htc/workspaces/{workspaceId}/limits operation.
-	//
-	// This endpoint will get the resource limit applied to this workspace.
-	//
-	// GET /htc/workspaces/{workspaceId}/limits
-	HtcWorkspacesWorkspaceIdLimitsGet(ctx context.Context, params HtcWorkspacesWorkspaceIdLimitsGetParams) (HtcWorkspacesWorkspaceIdLimitsGetRes, error)
-	// HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet implements GET /htc/workspaces/{workspaceId}/task-retention-policy operation.
-	//
-	// This endpoint is used to retrieve the current task retention policy of a specific Workspace. The
-	// task retention policy is necessary in managing the lifecycle of tasks within a Workspace. The task
-	// retention policy includes two key aspects:
-	// * **Deletion Grace Period**: The `deleteAfter` field represents the duration (in hours) after
-	// which an archived task is automatically deleted. Archived tasks can be unarchived during this
-	// period, protecting users from prematurely deleting task resources.
-	// * **Auto-Archive After Inactivity**: The `archiveAfter` field represents the duration (in hours)
-	// of inactivity after which an active task is automatically archived. This feature helps in keeping
-	// the project organized by archiving active tasks, ensuring that storage resources are freed
-	// optimistically.
-	// Setting either value to `0` will result in disabling of that feature. For example, a project's
-	// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
-	// auto-deleting.
-	//
-	// GET /htc/workspaces/{workspaceId}/task-retention-policy
-	HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet(ctx context.Context, params HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams) (HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes, error)
-	// HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut implements PUT /htc/workspaces/{workspaceId}/task-retention-policy operation.
-	//
-	// This endpoint enables Workspace administrators to define or update the task retention policy for a
-	// specific workspace. The task retention policy includes two key aspects:
-	// * **Deletion Grace Period**: The `deleteAfter` field allows administrators to set the duration (in
-	// hours) after which an archived task is automatically deleted. This control allows for flexibility
-	// in managing the lifecycle of tasks, ensuring that data is retained for an adequate period before
-	// being permanently deleted. Archived tasks can be unarchived during this period, protecting users
-	// from prematurely deleting task resources
-	// * **Auto-Archive After Inactivity**: The `archiveAfter` field allows administrators to specify the
-	// duration (in hours) of inactivity after which an active task is automatically archived. This
-	// feature helps in keeping the project organized by archiving active tasks, ensuring that storage
-	// resources are freed optimistically.
-	// Setting either value to `0` will result in disabling of that feature. For example, a workspace's
-	// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
-	// auto-deleting. The policy applies to all projects within the workspace that do not have their own
-	// project-level policy defined. If a project within the workspace has its own retention policy
-	// defined, the project-level policy takes precedence over the workspace-level policy.
-	//
-	// PUT /htc/workspaces/{workspaceId}/task-retention-policy
-	HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut(ctx context.Context, req OptWorkspaceTaskRetentionPolicy, params HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams) (HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes, error)
 	// OAuth2TokenPost implements POST /oauth2/token operation.
 	//
 	// This endpoint will get an OAuth access token.
@@ -464,20 +419,20 @@ type ProjectHandler interface {
 	//
 	// GET /htc/projects/{projectId}/dimensions
 	GetDimensions(ctx context.Context, params GetDimensionsParams) (GetDimensionsRes, error)
-	// GetLimits implements getLimits operation.
-	//
-	// This endpoint will list all resource limitations associated with this project.
-	// A job running in this project will be subject to all resulting limits as well as any associated
-	// with the workspace (see `/htc/workspaces/{workspaceId}/limits`).
-	//
-	// GET /htc/projects/{projectId}/limits
-	GetLimits(ctx context.Context, params GetLimitsParams) (GetLimitsRes, error)
 	// GetProject implements getProject operation.
 	//
 	// This endpoint will get a project by id.
 	//
 	// GET /htc/projects/{projectId}
 	GetProject(ctx context.Context, params GetProjectParams) (GetProjectRes, error)
+	// GetProjectLimits implements getProjectLimits operation.
+	//
+	// This endpoint will list all resource limitations associated with this project.
+	// A job running in this project will be subject to all resulting limits as well as any associated
+	// with the workspace (see `/htc/workspaces/{workspaceId}/limits`).
+	//
+	// GET /htc/projects/{projectId}/limits
+	GetProjectLimits(ctx context.Context, params GetProjectLimitsParams) (GetProjectLimitsRes, error)
 	// GetProjects implements getProjects operation.
 	//
 	// This endpoint will get all projects.
@@ -521,6 +476,51 @@ type WorkspaceHandler interface {
 	//
 	// GET /htc/gcp/clusters/{workspaceId}
 	GetGCPClusters(ctx context.Context, params GetGCPClustersParams) (GetGCPClustersRes, error)
+	// GetTaskRetentionPolicy implements getTaskRetentionPolicy operation.
+	//
+	// This endpoint is used to retrieve the current task retention policy of a specific Workspace. The
+	// task retention policy is necessary in managing the lifecycle of tasks within a Workspace. The task
+	// retention policy includes two key aspects:
+	// * **Deletion Grace Period**: The `deleteAfter` field represents the duration (in hours) after
+	// which an archived task is automatically deleted. Archived tasks can be unarchived during this
+	// period, protecting users from prematurely deleting task resources.
+	// * **Auto-Archive After Inactivity**: The `archiveAfter` field represents the duration (in hours)
+	// of inactivity after which an active task is automatically archived. This feature helps in keeping
+	// the project organized by archiving active tasks, ensuring that storage resources are freed
+	// optimistically.
+	// Setting either value to `0` will result in disabling of that feature. For example, a project's
+	// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
+	// auto-deleting.
+	//
+	// GET /htc/workspaces/{workspaceId}/task-retention-policy
+	GetTaskRetentionPolicy(ctx context.Context, params GetTaskRetentionPolicyParams) (GetTaskRetentionPolicyRes, error)
+	// GetWorkspaceLimits implements getWorkspaceLimits operation.
+	//
+	// This endpoint will get the resource limit applied to this workspace.
+	//
+	// GET /htc/workspaces/{workspaceId}/limits
+	GetWorkspaceLimits(ctx context.Context, params GetWorkspaceLimitsParams) (GetWorkspaceLimitsRes, error)
+	// PutTaskRetentionPolicy implements putTaskRetentionPolicy operation.
+	//
+	// This endpoint enables Workspace administrators to define or update the task retention policy for a
+	// specific workspace. The task retention policy includes two key aspects:
+	// * **Deletion Grace Period**: The `deleteAfter` field allows administrators to set the duration (in
+	// hours) after which an archived task is automatically deleted. This control allows for flexibility
+	// in managing the lifecycle of tasks, ensuring that data is retained for an adequate period before
+	// being permanently deleted. Archived tasks can be unarchived during this period, protecting users
+	// from prematurely deleting task resources
+	// * **Auto-Archive After Inactivity**: The `archiveAfter` field allows administrators to specify the
+	// duration (in hours) of inactivity after which an active task is automatically archived. This
+	// feature helps in keeping the project organized by archiving active tasks, ensuring that storage
+	// resources are freed optimistically.
+	// Setting either value to `0` will result in disabling of that feature. For example, a workspace's
+	// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
+	// auto-deleting. The policy applies to all projects within the workspace that do not have their own
+	// project-level policy defined. If a project within the workspace has its own retention policy
+	// defined, the project-level policy takes precedence over the workspace-level policy.
+	//
+	// PUT /htc/workspaces/{workspaceId}/task-retention-policy
+	PutTaskRetentionPolicy(ctx context.Context, req OptWorkspaceTaskRetentionPolicy, params PutTaskRetentionPolicyParams) (PutTaskRetentionPolicyRes, error)
 }
 
 // Server implements http server based on OpenAPI v3 specification and

--- a/v2/api/_oas/oas_server_gen.go
+++ b/v2/api/_oas/oas_server_gen.go
@@ -254,19 +254,6 @@ type Handler interface {
 	//
 	// GET /htc/storage/region/{region}
 	HtcStorageRegionRegionGet(ctx context.Context, params HtcStorageRegionRegionGetParams) (HtcStorageRegionRegionGetRes, error)
-	// HtcWorkspacesWorkspaceIdDimensionsGet implements GET /htc/workspaces/{workspaceId}/dimensions operation.
-	//
-	// This endpoint provides a comprehensive view of the various hardware configurations and
-	// environments available within a specific workspace. This read-only API is primarily designed for
-	// users who need to understand the different "dimensions" or attributes that describe the hardware
-	// and other aspects of job runs within their workspace. By offering insights into available
-	// environments, it aids users in selecting the most suitable configuration for their jobs,
-	// especially when performance testing across different hardware setups.
-	// Normal users can access this endpoint for the workspace they belong to
-	// Rescale personnel are required in order to modify any of these dimensions.
-	//
-	// GET /htc/workspaces/{workspaceId}/dimensions
-	HtcWorkspacesWorkspaceIdDimensionsGet(ctx context.Context, params HtcWorkspacesWorkspaceIdDimensionsGetParams) (HtcWorkspacesWorkspaceIdDimensionsGetRes, error)
 	// OAuth2TokenPost implements POST /oauth2/token operation.
 	//
 	// This endpoint will get an OAuth access token.
@@ -405,7 +392,13 @@ type ProjectHandler interface {
 	//
 	// POST /htc/projects
 	CreateProject(ctx context.Context, req OptHTCProject) (CreateProjectRes, error)
-	// GetDimensions implements getDimensions operation.
+	// GetProject implements getProject operation.
+	//
+	// This endpoint will get a project by id.
+	//
+	// GET /htc/projects/{projectId}
+	GetProject(ctx context.Context, params GetProjectParams) (GetProjectRes, error)
+	// GetProjectDimensions implements getProjectDimensions operation.
 	//
 	// This endpoint is designed to retrieve the current set of dimension combinations configured for a
 	// specific project so that users can understand the existing computing environment constraints of a
@@ -418,13 +411,7 @@ type ProjectHandler interface {
 	// currently configured `machineType`.
 	//
 	// GET /htc/projects/{projectId}/dimensions
-	GetDimensions(ctx context.Context, params GetDimensionsParams) (GetDimensionsRes, error)
-	// GetProject implements getProject operation.
-	//
-	// This endpoint will get a project by id.
-	//
-	// GET /htc/projects/{projectId}
-	GetProject(ctx context.Context, params GetProjectParams) (GetProjectRes, error)
+	GetProjectDimensions(ctx context.Context, params GetProjectDimensionsParams) (GetProjectDimensionsRes, error)
 	// GetProjectLimits implements getProjectLimits operation.
 	//
 	// This endpoint will list all resource limitations associated with this project.
@@ -494,6 +481,19 @@ type WorkspaceHandler interface {
 	//
 	// GET /htc/workspaces/{workspaceId}/task-retention-policy
 	GetTaskRetentionPolicy(ctx context.Context, params GetTaskRetentionPolicyParams) (GetTaskRetentionPolicyRes, error)
+	// GetWorkspaceDimensions implements getWorkspaceDimensions operation.
+	//
+	// This endpoint provides a comprehensive view of the various hardware configurations and
+	// environments available within a specific workspace. This read-only API is primarily designed for
+	// users who need to understand the different "dimensions" or attributes that describe the hardware
+	// and other aspects of job runs within their workspace. By offering insights into available
+	// environments, it aids users in selecting the most suitable configuration for their jobs,
+	// especially when performance testing across different hardware setups.
+	// Normal users can access this endpoint for the workspace they belong to
+	// Rescale personnel are required in order to modify any of these dimensions.
+	//
+	// GET /htc/workspaces/{workspaceId}/dimensions
+	GetWorkspaceDimensions(ctx context.Context, params GetWorkspaceDimensionsParams) (GetWorkspaceDimensionsRes, error)
 	// GetWorkspaceLimits implements getWorkspaceLimits operation.
 	//
 	// This endpoint will get the resource limit applied to this workspace.

--- a/v2/api/_oas/oas_unimplemented_gen.go
+++ b/v2/api/_oas/oas_unimplemented_gen.go
@@ -143,17 +143,6 @@ func (UnimplementedHandler) GetJobs(ctx context.Context, params GetJobsParams) (
 	return r, ht.ErrNotImplemented
 }
 
-// GetLimits implements getLimits operation.
-//
-// This endpoint will list all resource limitations associated with this project.
-// A job running in this project will be subject to all resulting limits as well as any associated
-// with the workspace (see `/htc/workspaces/{workspaceId}/limits`).
-//
-// GET /htc/projects/{projectId}/limits
-func (UnimplementedHandler) GetLimits(ctx context.Context, params GetLimitsParams) (r GetLimitsRes, _ error) {
-	return r, ht.ErrNotImplemented
-}
-
 // GetLogs implements getLogs operation.
 //
 // This endpoint will get job logs.
@@ -181,6 +170,17 @@ func (UnimplementedHandler) GetProject(ctx context.Context, params GetProjectPar
 	return r, ht.ErrNotImplemented
 }
 
+// GetProjectLimits implements getProjectLimits operation.
+//
+// This endpoint will list all resource limitations associated with this project.
+// A job running in this project will be subject to all resulting limits as well as any associated
+// with the workspace (see `/htc/workspaces/{workspaceId}/limits`).
+//
+// GET /htc/projects/{projectId}/limits
+func (UnimplementedHandler) GetProjectLimits(ctx context.Context, params GetProjectLimitsParams) (r GetProjectLimitsRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // GetProjects implements getProjects operation.
 //
 // This endpoint will get all projects.
@@ -199,6 +199,27 @@ func (UnimplementedHandler) GetProjects(ctx context.Context, params GetProjectsP
 //
 // GET /htc/projects/{projectId}/container-registry/token
 func (UnimplementedHandler) GetRegistryToken(ctx context.Context, params GetRegistryTokenParams) (r GetRegistryTokenRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// GetTaskRetentionPolicy implements getTaskRetentionPolicy operation.
+//
+// This endpoint is used to retrieve the current task retention policy of a specific Workspace. The
+// task retention policy is necessary in managing the lifecycle of tasks within a Workspace. The task
+// retention policy includes two key aspects:
+// * **Deletion Grace Period**: The `deleteAfter` field represents the duration (in hours) after
+// which an archived task is automatically deleted. Archived tasks can be unarchived during this
+// period, protecting users from prematurely deleting task resources.
+// * **Auto-Archive After Inactivity**: The `archiveAfter` field represents the duration (in hours)
+// of inactivity after which an active task is automatically archived. This feature helps in keeping
+// the project organized by archiving active tasks, ensuring that storage resources are freed
+// optimistically.
+// Setting either value to `0` will result in disabling of that feature. For example, a project's
+// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
+// auto-deleting.
+//
+// GET /htc/workspaces/{workspaceId}/task-retention-policy
+func (UnimplementedHandler) GetTaskRetentionPolicy(ctx context.Context, params GetTaskRetentionPolicyParams) (r GetTaskRetentionPolicyRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 
@@ -226,6 +247,15 @@ func (UnimplementedHandler) GetTasks(ctx context.Context, params GetTasksParams)
 //
 // GET /auth/token
 func (UnimplementedHandler) GetToken(ctx context.Context, params GetTokenParams) (r GetTokenRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// GetWorkspaceLimits implements getWorkspaceLimits operation.
+//
+// This endpoint will get the resource limit applied to this workspace.
+//
+// GET /htc/workspaces/{workspaceId}/limits
+func (UnimplementedHandler) GetWorkspaceLimits(ctx context.Context, params GetWorkspaceLimitsParams) (r GetWorkspaceLimitsRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 
@@ -565,37 +595,16 @@ func (UnimplementedHandler) HtcWorkspacesWorkspaceIdDimensionsGet(ctx context.Co
 	return r, ht.ErrNotImplemented
 }
 
-// HtcWorkspacesWorkspaceIdLimitsGet implements GET /htc/workspaces/{workspaceId}/limits operation.
+// OAuth2TokenPost implements POST /oauth2/token operation.
 //
-// This endpoint will get the resource limit applied to this workspace.
+// This endpoint will get an OAuth access token.
 //
-// GET /htc/workspaces/{workspaceId}/limits
-func (UnimplementedHandler) HtcWorkspacesWorkspaceIdLimitsGet(ctx context.Context, params HtcWorkspacesWorkspaceIdLimitsGetParams) (r HtcWorkspacesWorkspaceIdLimitsGetRes, _ error) {
+// POST /oauth2/token
+func (UnimplementedHandler) OAuth2TokenPost(ctx context.Context) (r OAuth2TokenPostRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 
-// HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet implements GET /htc/workspaces/{workspaceId}/task-retention-policy operation.
-//
-// This endpoint is used to retrieve the current task retention policy of a specific Workspace. The
-// task retention policy is necessary in managing the lifecycle of tasks within a Workspace. The task
-// retention policy includes two key aspects:
-// * **Deletion Grace Period**: The `deleteAfter` field represents the duration (in hours) after
-// which an archived task is automatically deleted. Archived tasks can be unarchived during this
-// period, protecting users from prematurely deleting task resources.
-// * **Auto-Archive After Inactivity**: The `archiveAfter` field represents the duration (in hours)
-// of inactivity after which an active task is automatically archived. This feature helps in keeping
-// the project organized by archiving active tasks, ensuring that storage resources are freed
-// optimistically.
-// Setting either value to `0` will result in disabling of that feature. For example, a project's
-// task retention policy with `deleteAfter` set to `0` will result in tasks within that project never
-// auto-deleting.
-//
-// GET /htc/workspaces/{workspaceId}/task-retention-policy
-func (UnimplementedHandler) HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet(ctx context.Context, params HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetParams) (r HtcWorkspacesWorkspaceIdTaskRetentionPolicyGetRes, _ error) {
-	return r, ht.ErrNotImplemented
-}
-
-// HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut implements PUT /htc/workspaces/{workspaceId}/task-retention-policy operation.
+// PutTaskRetentionPolicy implements putTaskRetentionPolicy operation.
 //
 // This endpoint enables Workspace administrators to define or update the task retention policy for a
 // specific workspace. The task retention policy includes two key aspects:
@@ -615,16 +624,7 @@ func (UnimplementedHandler) HtcWorkspacesWorkspaceIdTaskRetentionPolicyGet(ctx c
 // defined, the project-level policy takes precedence over the workspace-level policy.
 //
 // PUT /htc/workspaces/{workspaceId}/task-retention-policy
-func (UnimplementedHandler) HtcWorkspacesWorkspaceIdTaskRetentionPolicyPut(ctx context.Context, req OptWorkspaceTaskRetentionPolicy, params HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutParams) (r HtcWorkspacesWorkspaceIdTaskRetentionPolicyPutRes, _ error) {
-	return r, ht.ErrNotImplemented
-}
-
-// OAuth2TokenPost implements POST /oauth2/token operation.
-//
-// This endpoint will get an OAuth access token.
-//
-// POST /oauth2/token
-func (UnimplementedHandler) OAuth2TokenPost(ctx context.Context) (r OAuth2TokenPostRes, _ error) {
+func (UnimplementedHandler) PutTaskRetentionPolicy(ctx context.Context, req OptWorkspaceTaskRetentionPolicy, params PutTaskRetentionPolicyParams) (r PutTaskRetentionPolicyRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 

--- a/v2/api/_oas/oas_unimplemented_gen.go
+++ b/v2/api/_oas/oas_unimplemented_gen.go
@@ -66,25 +66,6 @@ func (UnimplementedHandler) CreateTask(ctx context.Context, req OptHTCTask, para
 	return r, ht.ErrNotImplemented
 }
 
-// GetDimensions implements getDimensions operation.
-//
-// This endpoint is designed to retrieve the current set of dimension combinations configured for a
-// specific project so that users can understand the existing computing environment constraints of a
-// project. It returns a list of dimension combinations such as pricing priority, geographical region,
-//
-//	compute scaling policy, and hyperthreading options.
-//
-// Any user who _belongs to the workspace this project belongs to_ can use this endpoint to verify or
-// audit the current configuration of a project. This can be helpful in ensuring that the project's
-// settings align with expectations.
-// The payload also includes a read-only set of `derived` dimensions which help describe the
-// currently configured `machineType`.
-//
-// GET /htc/projects/{projectId}/dimensions
-func (UnimplementedHandler) GetDimensions(ctx context.Context, params GetDimensionsParams) (r GetDimensionsRes, _ error) {
-	return r, ht.ErrNotImplemented
-}
-
 // GetEvents implements getEvents operation.
 //
 // This endpoint will get events for a job.
@@ -170,6 +151,25 @@ func (UnimplementedHandler) GetProject(ctx context.Context, params GetProjectPar
 	return r, ht.ErrNotImplemented
 }
 
+// GetProjectDimensions implements getProjectDimensions operation.
+//
+// This endpoint is designed to retrieve the current set of dimension combinations configured for a
+// specific project so that users can understand the existing computing environment constraints of a
+// project. It returns a list of dimension combinations such as pricing priority, geographical region,
+//
+//	compute scaling policy, and hyperthreading options.
+//
+// Any user who _belongs to the workspace this project belongs to_ can use this endpoint to verify or
+// audit the current configuration of a project. This can be helpful in ensuring that the project's
+// settings align with expectations.
+// The payload also includes a read-only set of `derived` dimensions which help describe the
+// currently configured `machineType`.
+//
+// GET /htc/projects/{projectId}/dimensions
+func (UnimplementedHandler) GetProjectDimensions(ctx context.Context, params GetProjectDimensionsParams) (r GetProjectDimensionsRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // GetProjectLimits implements getProjectLimits operation.
 //
 // This endpoint will list all resource limitations associated with this project.
@@ -247,6 +247,22 @@ func (UnimplementedHandler) GetTasks(ctx context.Context, params GetTasksParams)
 //
 // GET /auth/token
 func (UnimplementedHandler) GetToken(ctx context.Context, params GetTokenParams) (r GetTokenRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// GetWorkspaceDimensions implements getWorkspaceDimensions operation.
+//
+// This endpoint provides a comprehensive view of the various hardware configurations and
+// environments available within a specific workspace. This read-only API is primarily designed for
+// users who need to understand the different "dimensions" or attributes that describe the hardware
+// and other aspects of job runs within their workspace. By offering insights into available
+// environments, it aids users in selecting the most suitable configuration for their jobs,
+// especially when performance testing across different hardware setups.
+// Normal users can access this endpoint for the workspace they belong to
+// Rescale personnel are required in order to modify any of these dimensions.
+//
+// GET /htc/workspaces/{workspaceId}/dimensions
+func (UnimplementedHandler) GetWorkspaceDimensions(ctx context.Context, params GetWorkspaceDimensionsParams) (r GetWorkspaceDimensionsRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 
@@ -576,22 +592,6 @@ func (UnimplementedHandler) HtcStorageGet(ctx context.Context) (r HtcStorageGetR
 //
 // GET /htc/storage/region/{region}
 func (UnimplementedHandler) HtcStorageRegionRegionGet(ctx context.Context, params HtcStorageRegionRegionGetParams) (r HtcStorageRegionRegionGetRes, _ error) {
-	return r, ht.ErrNotImplemented
-}
-
-// HtcWorkspacesWorkspaceIdDimensionsGet implements GET /htc/workspaces/{workspaceId}/dimensions operation.
-//
-// This endpoint provides a comprehensive view of the various hardware configurations and
-// environments available within a specific workspace. This read-only API is primarily designed for
-// users who need to understand the different "dimensions" or attributes that describe the hardware
-// and other aspects of job runs within their workspace. By offering insights into available
-// environments, it aids users in selecting the most suitable configuration for their jobs,
-// especially when performance testing across different hardware setups.
-// Normal users can access this endpoint for the workspace they belong to
-// Rescale personnel are required in order to modify any of these dimensions.
-//
-// GET /htc/workspaces/{workspaceId}/dimensions
-func (UnimplementedHandler) HtcWorkspacesWorkspaceIdDimensionsGet(ctx context.Context, params HtcWorkspacesWorkspaceIdDimensionsGetParams) (r HtcWorkspacesWorkspaceIdDimensionsGetRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 

--- a/v2/api/_oas/oas_validators_gen.go
+++ b/v2/api/_oas/oas_validators_gen.go
@@ -1876,6 +1876,31 @@ func (s *HTCTasksResponse) Validate() error {
 	return nil
 }
 
+func (s HTCWorkspaceDimensions) Validate() error {
+	alias := ([]HTCComputeEnvironment)(s)
+	if alias == nil {
+		return errors.New("nil is invalid value")
+	}
+	var failures []validate.FieldError
+	for i, elem := range alias {
+		if err := func() error {
+			if err := elem.Validate(); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			failures = append(failures, validate.FieldError{
+				Name:  fmt.Sprintf("[%d]", i),
+				Error: err,
+			})
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *HTCWorkspaceLimit) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -1986,31 +2011,6 @@ func (s HtcProjectsProjectIdTasksTaskIdGroupsGetOKApplicationJSON) Validate() er
 
 func (s HtcStorageGetOKApplicationJSON) Validate() error {
 	alias := ([]RegionStorageOption)(s)
-	if alias == nil {
-		return errors.New("nil is invalid value")
-	}
-	var failures []validate.FieldError
-	for i, elem := range alias {
-		if err := func() error {
-			if err := elem.Validate(); err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			failures = append(failures, validate.FieldError{
-				Name:  fmt.Sprintf("[%d]", i),
-				Error: err,
-			})
-		}
-	}
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
-	}
-	return nil
-}
-
-func (s HtcWorkspacesWorkspaceIdDimensionsGetOKApplicationJSON) Validate() error {
-	alias := ([]HTCComputeEnvironment)(s)
 	if alias == nil {
 		return errors.New("nil is invalid value")
 	}

--- a/v2/api/swagger-patched.json
+++ b/v2/api/swagger-patched.json
@@ -2897,7 +2897,7 @@
          },
          "get": {
             "description": "This endpoint will list all resource limitations associated with this project.\n\nA job running in this project will be subject to all resulting limits as well as any associated with the workspace (see `/htc/workspaces/{workspaceId}/limits`)",
-            "operationId": "getLimits",
+            "operationId": "getProjectLimits",
             "parameters": [
                {
                   "in": "path",
@@ -5303,6 +5303,7 @@
       "/htc/workspaces/{workspaceId}/limits": {
          "get": {
             "description": "This endpoint will get the resource limit applied to this workspace",
+            "operationId": "getWorkspaceLimits",
             "parameters": [
                {
                   "in": "path",
@@ -5349,12 +5350,14 @@
             "summary": "Get Workspace Limit",
             "tags": [
                "Workspace Resource"
-            ]
+            ],
+            "x-ogen-operation-group": "Workspace"
          }
       },
       "/htc/workspaces/{workspaceId}/task-retention-policy": {
          "get": {
             "description": "This endpoint is used to retrieve the current task retention policy of a specific Workspace. The task retention policy is necessary in managing the lifecycle of tasks within a Workspace. The task retention policy includes two key aspects:\n\n* **Deletion Grace Period**: The `deleteAfter` field represents the duration (in hours) after which an archived task is automatically deleted. Archived tasks can be unarchived during this period, protecting users from prematurely deleting task resources.\n\n* **Auto-Archive After Inactivity**: The `archiveAfter` field represents the duration (in hours) of inactivity after which an active task is automatically archived. This feature helps in keeping the project organized by archiving active tasks, ensuring that storage resources are freed optimistically.\n\nSetting either value to `0` will result in disabling of that feature. For example, a project's task retention policy with `deleteAfter` set to `0` will result in tasks within that project never auto-deleting.",
+            "operationId": "getTaskRetentionPolicy",
             "parameters": [
                {
                   "in": "path",
@@ -5401,10 +5404,12 @@
             "summary": "Get Workspace Task Retention Policy",
             "tags": [
                "Workspace Resource"
-            ]
+            ],
+            "x-ogen-operation-group": "Workspace"
          },
          "put": {
             "description": "This endpoint enables Workspace administrators to define or update the task retention policy for a specific workspace. The task retention policy includes two key aspects:\n\n* **Deletion Grace Period**: The `deleteAfter` field allows administrators to set the duration (in hours) after which an archived task is automatically deleted. This control allows for flexibility in managing the lifecycle of tasks, ensuring that data is retained for an adequate period before being permanently deleted. Archived tasks can be unarchived during this period, protecting users from prematurely deleting task resources\n\n* **Auto-Archive After Inactivity**: The `archiveAfter` field allows administrators to specify the duration (in hours) of inactivity after which an active task is automatically archived. This feature helps in keeping the project organized by archiving active tasks, ensuring that storage resources are freed optimistically.\n\nSetting either value to `0` will result in disabling of that feature. For example, a workspace's task retention policy with `deleteAfter` set to `0` will result in tasks within that project never auto-deleting. The policy applies to all projects within the workspace that do not have their own project-level policy defined. If a project within the workspace has its own retention policy defined, the project-level policy takes precedence over the workspace-level policy.",
+            "operationId": "putTaskRetentionPolicy",
             "parameters": [
                {
                   "in": "path",
@@ -5450,6 +5455,9 @@
                      }
                   },
                   "description": "Not Found"
+               },
+               "405": {
+                  "description": "Not Allowed"
                }
             },
             "security": [
@@ -5460,7 +5468,8 @@
             "summary": "Modify Workspace Task Retention Policy",
             "tags": [
                "Workspace Resource"
-            ]
+            ],
+            "x-ogen-operation-group": "Workspace"
          }
       },
       "/oauth2/token": {

--- a/v2/api/swagger-patched.json
+++ b/v2/api/swagger-patched.json
@@ -1227,6 +1227,12 @@
          "HTCTokenPayload": {
             "type": "string"
          },
+         "HTCWorkspaceDimensions": {
+            "items": {
+               "$ref": "#/components/schemas/HTCComputeEnvironment"
+            },
+            "type": "array"
+         },
          "HTCWorkspaceLimit": {
             "properties": {
                "createdAt": {
@@ -2735,7 +2741,7 @@
       "/htc/projects/{projectId}/dimensions": {
          "get": {
             "description": "This endpoint is designed to retrieve the current set of dimension combinations configured for a specific project so that users can understand the existing computing environment constraints of a project. It returns a list of dimension combinations such as pricing priority, geographical region, compute scaling policy, and hyperthreading options.\n\nAny user who _belongs to the workspace this project belongs to_ can use this endpoint to verify or audit the current configuration of a project. This can be helpful in ensuring that the project's settings align with expectations.\n\nThe payload also includes a read-only set of `derived` dimensions which help describe the currently configured `machineType`",
-            "operationId": "getDimensions",
+            "operationId": "getProjectDimensions",
             "parameters": [
                {
                   "in": "path",
@@ -5248,6 +5254,7 @@
       "/htc/workspaces/{workspaceId}/dimensions": {
          "get": {
             "description": "This endpoint provides a comprehensive view of the various hardware configurations and environments available within a specific workspace. This read-only API is primarily designed for users who need to understand the different \"dimensions\" or attributes that describe the hardware and other aspects of job runs within their workspace. By offering insights into available environments, it aids users in selecting the most suitable configuration for their jobs, especially when performance testing across different hardware setups.\n\nNormal users can access this endpoint for the workspace they belong to\n\nRescale personnel are required in order to modify any of these dimensions.",
+            "operationId": "getWorkspaceDimensions",
             "parameters": [
                {
                   "in": "path",
@@ -5263,10 +5270,7 @@
                   "content": {
                      "application/json": {
                         "schema": {
-                           "items": {
-                              "$ref": "#/components/schemas/HTCComputeEnvironment"
-                           },
-                           "type": "array"
+                           "$ref": "#/components/schemas/HTCWorkspaceDimensions"
                         }
                      }
                   },
@@ -5297,7 +5301,8 @@
             "summary": "Get Workspace Dimensions",
             "tags": [
                "Workspace Resource"
-            ]
+            ],
+            "x-ogen-operation-group": "Workspace"
          }
       },
       "/htc/workspaces/{workspaceId}/limits": {

--- a/v2/api/swagger.jsonnet
+++ b/v2/api/swagger.jsonnet
@@ -117,7 +117,7 @@ local patches = {
     '/htc/projects/{projectId}/dimensions'+: {
       get+: {
         'x-ogen-operation-group': 'Project',
-        operationId: 'getDimensions',
+        operationId: 'getProjectDimensions',
         responses+: {
           '200'+: {
             content+: {
@@ -283,6 +283,21 @@ local patches = {
           },
         }
       }
+    },
+    '/htc/workspaces/{workspaceId}/dimensions'+: {
+      get+: {
+        'x-ogen-operation-group': 'Workspace',
+        operationId: 'getWorkspaceDimensions',
+        responses+: {
+          '200'+: {
+            content+: {
+              'application/json'+: {
+                schema: { '$ref': '#/components/schemas/HTCWorkspaceDimensions' },
+              },
+            },
+          },
+        },
+      },
     },
     '/htc/workspaces/{workspaceId}/limits'+: {
       get+: {
@@ -505,6 +520,12 @@ local patches = {
             type: 'string',
             example: 'https://page2.com',
           },
+        },
+      },
+      HTCWorkspaceDimensions: {
+        type: 'array',
+        items: {
+          '$ref': '#/components/schemas/HTCComputeEnvironment',
         },
       },
       HTCTokenPayload: { type: 'string' },

--- a/v2/api/swagger.jsonnet
+++ b/v2/api/swagger.jsonnet
@@ -39,23 +39,6 @@ local patches = {
         security: securityScheme,
       },
     },
-    '/htc/gcp/clusters/{workspaceId}'+: {
-      get+: {
-        'x-ogen-operation-group': 'Workspace',
-        operationId: 'getGCPClusters',
-        responses+: {
-          '200'+: {
-            content+: {
-              'application/json'+: {
-                schema: { '$ref':
-                  '#/components/schemas/HTCClusterStatusResponse' },
-
-              },
-            },
-          },
-        },
-      },
-    },
     '/htc/metrics'+: {
       get+: {
         'x-ogen-operation-group': 'Metrics',
@@ -149,7 +132,7 @@ local patches = {
     '/htc/projects/{projectId}/limits'+: {
       get+: {
         'x-ogen-operation-group': 'Project',
-        operationId: 'getLimits',
+        operationId: 'getProjectLimits',
         responses+: {
           '200'+: {
             content+: {
@@ -182,12 +165,12 @@ local patches = {
         operationId: 'createTask',
       },
     },
-  '/htc/projects/{projectId}/tasks/{taskId}/summary-statistics'+: {
-    get+: {
-      'x-ogen-operation-group': 'Task',
-      operationId: 'GetTaskStats',
-    }
-  },
+    '/htc/projects/{projectId}/tasks/{taskId}/summary-statistics'+: {
+      get+: {
+        'x-ogen-operation-group': 'Task',
+        operationId: 'GetTaskStats',
+      }
+    },
     '/htc/projects/{projectId}/tasks/{taskId}/jobs'+: {
       get+: {
         'x-ogen-operation-group': 'Job',
@@ -300,7 +283,45 @@ local patches = {
           },
         }
       }
-    }
+    },
+    '/htc/workspaces/{workspaceId}/limits'+: {
+      get+: {
+        'x-ogen-operation-group': 'Workspace',
+        operationId: 'getWorkspaceLimits',
+      },
+    },
+    '/htc/workspaces/{workspaceId}/task-retention-policy'+: {
+      get+: {
+        'x-ogen-operation-group': 'Workspace',
+        operationId: 'getTaskRetentionPolicy',
+      },
+      put+: {
+        'x-ogen-operation-group': 'Workspace',
+        operationId: 'putTaskRetentionPolicy',
+        responses+: {
+          '405'+: {
+            description: "Not Allowed"
+          },
+        },
+      },
+    },
+    '/htc/gcp/clusters/{workspaceId}'+: {
+      get+: {
+        'x-ogen-operation-group': 'Workspace',
+        operationId: 'getGCPClusters',
+        responses+: {
+          '200'+: {
+            content+: {
+              'application/json'+: {
+                schema: { '$ref':
+                  '#/components/schemas/HTCClusterStatusResponse' },
+
+              },
+            },
+          },
+        },
+      },
+    },
   },
   components+: {
     schemas+: {

--- a/v2/commands/project/limits.go
+++ b/v2/commands/project/limits.go
@@ -24,8 +24,8 @@ func LimitsGet(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.Background()
-	res, err := runner.Client.GetLimits(ctx,
-		oapi.GetLimitsParams{ProjectId: p.ProjectId})
+	res, err := runner.Client.GetProjectLimits(ctx,
+		oapi.GetProjectLimitsParams{ProjectId: p.ProjectId})
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func LimitsGet(cmd *cobra.Command, args []string) error {
 	switch res := res.(type) {
 	case *oapi.HTCProjectLimits:
 		return runner.PrintResult(res, os.Stdout)
-	case *oapi.GetLimitsForbidden, *oapi.GetLimitsUnauthorized:
+	case *oapi.GetProjectLimitsForbidden, *oapi.GetProjectLimitsUnauthorized:
 		return fmt.Errorf("forbidden: %s", res)
 	}
 

--- a/v2/commands/workspace/command.go
+++ b/v2/commands/workspace/command.go
@@ -11,4 +11,5 @@ var WorkspaceCmd = &cobra.Command{
 
 func init() {
 	WorkspaceCmd.AddCommand(ClustersCmd)
+	WorkspaceCmd.AddCommand(RetentionPolicyCmd)
 }

--- a/v2/commands/workspace/command.go
+++ b/v2/commands/workspace/command.go
@@ -12,4 +12,5 @@ var WorkspaceCmd = &cobra.Command{
 func init() {
 	WorkspaceCmd.AddCommand(ClustersCmd)
 	WorkspaceCmd.AddCommand(RetentionPolicyCmd)
+	WorkspaceCmd.AddCommand(DimensionsCmd)
 }

--- a/v2/commands/workspace/dimensions.go
+++ b/v2/commands/workspace/dimensions.go
@@ -1,4 +1,4 @@
-package project
+package workspace
 
 import (
 	"context"
@@ -19,54 +19,39 @@ func DimensionsGet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	p := common.IDParams{RequireProjectId: true}
+	p := common.IDParams{RequireWorkspaceId: true}
 	if err := runner.GetIds(&p); err != nil {
 		return err
 	}
 
 	ctx := context.Background()
-	res, err := runner.Client.GetProjectDimensions(ctx,
-		oapi.GetProjectDimensionsParams{ProjectId: p.ProjectId})
+	res, err := runner.Client.GetWorkspaceDimensions(ctx,
+		oapi.GetWorkspaceDimensionsParams{WorkspaceId: p.WorkspaceId})
 	if err != nil {
 		return err
 	}
 
 	switch res := res.(type) {
-	case *oapi.HTCProjectDimensions:
+	case *oapi.HTCWorkspaceDimensions:
 		return runner.PrintResult((*tabler.ComputeEnvs)(res), os.Stdout)
-	case *oapi.GetProjectDimensionsForbidden,
-		*oapi.GetProjectDimensionsUnauthorized:
+	case *oapi.GetWorkspaceDimensionsForbidden,
+		*oapi.GetWorkspaceDimensionsUnauthorized:
 		return fmt.Errorf("forbidden: %s", res)
 	}
-
 	return fmt.Errorf("Unknown response type: %s", res)
 }
 
 var DimensionsCmd = &cobra.Command{
 	Use:   "dimensions",
-	Short: "Commands for project dimensions",
+	Short: "Commands for workspace dimensions",
 }
 
 var DimensionsGetCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Returns dimensions for an HTC project",
+	Short: "Returns dimensions for an HTC workspace",
 	Run:   common.WrapRunE(DimensionsGet),
 	Args:  cobra.ExactArgs(0),
 }
-
-// var DimensionsApplyCmd = &cobra.Command{
-// 	Use:   "apply",
-// 	Short: "Sets dimensions for an HTC project",
-// 	Run:   common.WrapRunE(DimensionsGet),
-// 	Args:  cobra.ExactArgs(0),
-// }
-//
-// var DimensionsDeleteCmd = &cobra.Command{
-// 	Use:   "delete",
-// 	Short: "Deletes dimensions for an HTC project",
-// 	Run:   common.WrapRunE(DimensionsGet),
-// 	Args:  cobra.ExactArgs(0),
-// }
 
 func init() {
 	DimensionsCmd.AddCommand(DimensionsGetCmd)

--- a/v2/commands/workspace/retention_policy.go
+++ b/v2/commands/workspace/retention_policy.go
@@ -1,0 +1,130 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	oapi "github.com/rescale-labs/htc-cli/v2/api/_oas"
+	"github.com/rescale-labs/htc-cli/v2/common"
+)
+
+func TaskRetentionPolicyGet(cmd *cobra.Command, args []string) error {
+	runner, err := common.NewRunnerWithToken(cmd, time.Now())
+	if err != nil {
+		return err
+	}
+
+	p := common.IDParams{RequireWorkspaceId: true}
+	if err := runner.GetIds(&p); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	res, err := runner.Client.GetTaskRetentionPolicy(ctx, oapi.GetTaskRetentionPolicyParams{
+		WorkspaceId: p.WorkspaceId,
+	})
+	if err != nil {
+		return err
+	}
+
+	switch res := res.(type) {
+	case *oapi.WorkspaceTaskRetentionPolicy:
+		return runner.PrintResult(res, os.Stdout)
+	case *oapi.GetTaskRetentionPolicyForbidden,
+		*oapi.GetTaskRetentionPolicyUnauthorized:
+		return fmt.Errorf("forbidden: %s", res)
+	}
+	return fmt.Errorf("Unknown response type: %s", res)
+}
+
+func TaskRetentionPolicyPut(cmd *cobra.Command, args []string) error {
+	runner, err := common.NewRunnerWithToken(cmd, time.Now())
+	if err != nil {
+		return err
+	}
+
+	p := common.IDParams{RequireWorkspaceId: true}
+	if err := runner.GetIds(&p); err != nil {
+		return err
+	}
+
+	f, err := common.OpenArg(args[0])
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	var policy oapi.WorkspaceTaskRetentionPolicy
+	if err := dec.Decode(&policy); err != nil {
+		return err
+	}
+
+
+	ctx := context.Background()
+	res, err := runner.Client.PutTaskRetentionPolicy(ctx,
+		oapi.NewOptWorkspaceTaskRetentionPolicy(policy),
+		oapi.PutTaskRetentionPolicyParams{
+			WorkspaceId: p.WorkspaceId,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	switch res := res.(type) {
+	case *oapi.WorkspaceTaskRetentionPolicy:
+		return runner.PrintResult(res, os.Stdout)
+	case *oapi.PutTaskRetentionPolicyMethodNotAllowed:
+		return fmt.Errorf("not allowed: %s", res)
+	case *oapi.PutTaskRetentionPolicyUnauthorized, *oapi.PutTaskRetentionPolicyForbidden:
+		return fmt.Errorf("forbidden: %s", res)
+	}
+	return nil
+}
+
+var RetentionPolicyCmd = &cobra.Command{
+	Use: 	"retention-policy",
+	Short: 	"Commands for workspace-scoped task retention policy",
+}
+
+var RetentionPolicyGetCmd = &cobra.Command{
+	Use: 	"get",
+	Short: 	"Returns task retention policy to a workspace.",
+	Run:	common.WrapRunE(TaskRetentionPolicyGet),
+	Args: 	cobra.ExactArgs(0),
+}
+
+var RetentionPolicyApplyCmd = &cobra.Command{
+	Use:	"apply JSON_FILE",
+	Short: 	"Apply task retention policy to a workspace.",
+	Run:	common.WrapRunE(TaskRetentionPolicyPut),
+	Args:	cobra.ExactArgs(1),
+}
+
+func init() {
+	// example retention policy JSON payload
+
+	policy := oapi.WorkspaceTaskRetentionPolicy{
+		ArchiveAfter: 24, // hours
+		DeleteAfter: 168, // hours
+	}
+	b, err := json.MarshalIndent(&policy, "", "  ")
+	if err != nil {
+		panic("Unable to serialize `retention-policy apply` JSON example: " + err.Error())
+	}
+	RetentionPolicyApplyCmd.Long = RetentionPolicyApplyCmd.Short + `
+JSON_FILE is a path to a JSON file or - for stdin.`
+	RetentionPolicyApplyCmd.Example = fmt.Sprintf(`
+htc workspace retention-policy apply - <<'EOF'
+  %s
+EOF`, string(b))
+
+	RetentionPolicyCmd.AddCommand(RetentionPolicyGetCmd)
+	RetentionPolicyCmd.AddCommand(RetentionPolicyApplyCmd)
+}

--- a/v2/commands/workspace/retention_policy.go
+++ b/v2/commands/workspace/retention_policy.go
@@ -109,7 +109,6 @@ var RetentionPolicyApplyCmd = &cobra.Command{
 
 func init() {
 	// example retention policy JSON payload
-
 	policy := oapi.WorkspaceTaskRetentionPolicy{
 		ArchiveAfter: 24, // hours
 		DeleteAfter: 168, // hours

--- a/v2/tabler/dimensions.go
+++ b/v2/tabler/dimensions.go
@@ -15,7 +15,7 @@ func (c *ComputeEnvs) Fields() []Field {
 		Field{"Machine Type", "%-20s", "%-20.20s"},
 		Field{"Priority", "%-8s", "%-8.8s"},
 		Field{"HT", "%-2s", " %1.1s"},
-		Field{"Arch", "%-5s", "%-5s"},
+		Field{"Arch", "%-10s", "%-10s"},
 		Field{"vCPU", "%-4s", "%4d"},
 		Field{"Mem", "%-3s", "%-3.0f"},
 		Field{"Swap", "%-4s", "%4s"},


### PR DESCRIPTION
JIRA: https://rescale.atlassian.net/browse/ENK-2650

Some minor changes from the spec in TODO:
- Limits endpoints 404
- No dimensions PUT implementation in API

## Retention policy
apply(PUT), get
![image](https://github.com/user-attachments/assets/20e185f1-6672-44b3-959b-f6f7f5fb6c02)

## Dimensions
get
![image](https://github.com/user-attachments/assets/ded153b2-c9b3-4a22-bace-fce1fbbc49ad)
